### PR TITLE
Refactor macros which convert kernel security structures to our internal structures

### DIFF
--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -928,7 +928,7 @@ static int medusa_l1_socket_post_create(struct socket *sock, int family, int typ
 	struct medusa_l1_socket_s *sk_sec;
 
 	if (sock->sk) {
-		sk_sec = &sock_security(sock->sk);
+		sk_sec = sock_security(sock->sk);
 		sk_sec->addrlen = 0;
 	}
 

--- a/security/medusa/l2/acctype_afterexec.c
+++ b/security/medusa/l2/acctype_afterexec.c
@@ -37,11 +37,11 @@ medusa_answer_t medusa_afterexec(char *filename, char **argv, char **envp)
         memset(&access, '\0', sizeof(struct afterexec_access));
         /* process_kobject process is zeroed by process_kern2kobj function */
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (MEDUSA_MONITORED_ACCESS_S(afterexec_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(afterexec_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		retval = MED_DECIDE(afterexec_access, &access,
 				&process, &process);
@@ -52,16 +52,16 @@ medusa_answer_t medusa_afterexec(char *filename, char **argv, char **envp)
 }
 int medusa_monitored_afterexec(void)
 {
-	return MEDUSA_MONITORED_ACCESS_S(afterexec_access, &task_security(current));
+	return MEDUSA_MONITORED_ACCESS_S(afterexec_access, task_security(current));
 }
 
 void medusa_monitor_afterexec(int flag)
 {
 	if (flag)
 		MEDUSA_MONITOR_ACCESS_S(afterexec_access,
-				&task_security(current));
+				task_security(current));
 	else
 		MEDUSA_UNMONITOR_ACCESS_S(afterexec_access,
-				&task_security(current));
+				task_security(current));
 }
 __initcall(afterexec_acctype_init);

--- a/security/medusa/l2/acctype_capable.c
+++ b/security/medusa/l2/acctype_capable.c
@@ -43,11 +43,11 @@ medusa_answer_t medusa_capable(int cap)
 #warning "finish me"
 		return MED_OK;
 	}
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (MEDUSA_MONITORED_ACCESS_S(capable_access,&task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(capable_access,task_security(current))) {
 		access.cap = CAP_TO_MASK(cap);
 		process_kern2kobj(&process, current);
 		retval = MED_DECIDE(capable_access, &access, &process, &process);

--- a/security/medusa/l2/acctype_create.c
+++ b/security/medusa/l2/acctype_create.c
@@ -40,7 +40,7 @@ medusa_answer_t medusa_create(struct dentry *dentry, int mode)
 
 	if (!dentry || IS_ERR(dentry))
 		return MED_OK;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
@@ -48,18 +48,18 @@ medusa_answer_t medusa_create(struct dentry *dentry, int mode)
 	ndcurrent.mnt = NULL;
 	medusa_get_upper_and_parent(&ndcurrent,&ndupper,&ndparent);
 
-	if (!is_med_magic_valid(&(&inode_security(ndparent.dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(ndparent.dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(ndparent.dentry,ndparent.mnt) <= 0) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(ndparent.dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(ndparent.dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(ndparent.dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(ndparent.dentry->d_inode)))
 	) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_NO;
 	}
-	if (MEDUSA_MONITORED_ACCESS_O(create_access, &inode_security(ndparent.dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(create_access, inode_security(ndparent.dentry->d_inode)))
 		retval = medusa_do_create(ndparent.dentry, ndupper.dentry, mode);
 	else
 		retval = MED_OK;

--- a/security/medusa/l2/acctype_exec.c
+++ b/security/medusa/l2/acctype_exec.c
@@ -50,24 +50,24 @@ medusa_answer_t medusa_exec(struct dentry ** dentryp)
 
 	if (!*dentryp || IS_ERR(*dentryp) || !(*dentryp)->d_inode)
 		return MED_OK;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security((*dentryp)->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security((*dentryp)->d_inode)->med_object)) &&
 
 			file_kobj_validate_dentry(*dentryp,NULL) <= 0)
 		return MED_OK;
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security((*dentryp)->d_inode))) ||
-		!vs_intersects(VSR(&task_security(current)),VS(&inode_security((*dentryp)->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security((*dentryp)->d_inode))) ||
+		!vs_intersects(VSR(task_security(current)),VS(inode_security((*dentryp)->d_inode)))
 	)
 		return MED_NO;
-	if (MEDUSA_MONITORED_ACCESS_S(exec_paccess, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(exec_paccess, task_security(current))) {
 		retval = medusa_do_pexec(*dentryp);
 		if (retval == MED_NO)
 			return retval;
 	}
-	if (MEDUSA_MONITORED_ACCESS_O(exec_faccess, &inode_security((*dentryp)->d_inode))) {
+	if (MEDUSA_MONITORED_ACCESS_O(exec_faccess, inode_security((*dentryp)->d_inode))) {
 		retval = medusa_do_fexec(*dentryp);
 		return retval;
 	}
@@ -115,14 +115,14 @@ static medusa_answer_t medusa_do_pexec(struct dentry *dentry)
 }
 int medusa_monitored_pexec(void)
 {
-	return MEDUSA_MONITORED_ACCESS_S(exec_paccess, &task_security(current));
+	return MEDUSA_MONITORED_ACCESS_S(exec_paccess, task_security(current));
 }
 
 void medusa_monitor_pexec(int flag)
 {
 	if (flag)
-		MEDUSA_MONITOR_ACCESS_S(exec_paccess, &task_security(current));
+		MEDUSA_MONITOR_ACCESS_S(exec_paccess, task_security(current));
 	else
-		MEDUSA_UNMONITOR_ACCESS_S(exec_paccess, &task_security(current));
+		MEDUSA_UNMONITOR_ACCESS_S(exec_paccess, task_security(current));
 }
 __initcall(exec_acctype_init);

--- a/security/medusa/l2/acctype_fork.c
+++ b/security/medusa/l2/acctype_fork.c
@@ -32,11 +32,11 @@ medusa_answer_t medusa_fork(unsigned long clone_flags)
         memset(&access, '\0', sizeof(struct fork_access));
         /* process_kobject parent is zeroed by process_kern2kobj function */
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (MEDUSA_MONITORED_ACCESS_S(fork_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(fork_access, task_security(current))) {
 		access.clone_flags = clone_flags;
 		process_kern2kobj(&parent, current);
 		retval = MED_DECIDE(fork_access, &access, &parent, &parent);

--- a/security/medusa/l2/acctype_init_process.c
+++ b/security/medusa/l2/acctype_init_process.c
@@ -30,12 +30,12 @@ medusa_answer_t medusa_init_process(struct task_struct *new)
         /* process_kobject process is zeroed by process_kern2kobj function */
         /* process_kobject parent is zeroed by process_kern2kobj function */
 
-	if (!is_med_magic_valid(&(&task_security(new))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(new)->med_object)) &&
 		process_kobj_validate_task(new) <= 0)
 		return MED_OK;
 
 	/* inherit from parent if the action isn't monitored? */
-	if (MEDUSA_MONITORED_ACCESS_S(init_process, &task_security(new))) {
+	if (MEDUSA_MONITORED_ACCESS_S(init_process, task_security(new))) {
 		process_kern2kobj(&process, new);
 		process_kern2kobj(&parent, current);
 		retval = MED_DECIDE(init_process, &access, &process, &parent);
@@ -47,8 +47,8 @@ medusa_answer_t medusa_init_process(struct task_struct *new)
 
 void medusa_kernel_thread(int (*fn) (void *))
 {
-	init_med_object(&(&task_security(current))->med_object);
-	init_med_subject(&(&task_security(current))->med_subject);
-	task_security(current).luid = INVALID_UID;
+	init_med_object(&(task_security(current)->med_object));
+	init_med_subject(&(task_security(current)->med_subject));
+	task_security(current)->luid = INVALID_UID;
 }
 __initcall(init_process_acctype_init);

--- a/security/medusa/l2/acctype_ipc_associate.c
+++ b/security/medusa/l2/acctype_ipc_associate.c
@@ -58,19 +58,19 @@ medusa_answer_t medusa_ipc_associate(struct kern_ipc_perm *ipcp, int flag)
 		/* for now, we don't support error codes */
 		return MED_NO;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		goto out;
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (!vs_intersects(VSS(&task_security(current)),VS(ipc_security(ipcp))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(ipc_security(ipcp)))
+	if (!vs_intersects(VSS(task_security(current)),VS(ipc_security(ipcp))) ||
+		!vs_intersects(VSW(task_security(current)),VS(ipc_security(ipcp)))
 	) {
 		retval = MED_NO;
 		goto out;
 	}
 	
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_associate_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(ipc_associate_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_ctl.c
+++ b/security/medusa/l2/acctype_ipc_ctl.c
@@ -86,10 +86,10 @@ medusa_answer_t medusa_ipc_ctl(struct kern_ipc_perm *ipcp, int cmd)
 			goto out;
 	}
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_ctl_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(ipc_ctl_access, task_security(current))) {
 		memset(&access, '\0', sizeof(struct ipc_ctl_access));
 		access.cmd = cmd;
 		access.ipc_class = MED_IPC_UNDEFINED;

--- a/security/medusa/l2/acctype_ipc_msgrcv.c
+++ b/security/medusa/l2/acctype_ipc_msgrcv.c
@@ -70,12 +70,12 @@ medusa_answer_t medusa_ipc_msgrcv(struct kern_ipc_perm *ipcp, struct msg_msg *ms
 		/* for now, we don't support error codes */
 		return MED_NO;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		goto out;
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_msgrcv_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(ipc_msgrcv_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_msgsnd.c
+++ b/security/medusa/l2/acctype_ipc_msgsnd.c
@@ -55,12 +55,12 @@ medusa_answer_t medusa_ipc_msgsnd(struct kern_ipc_perm *ipcp, struct msg_msg *ms
 		/* for now, we don't support error codes */
 		return MED_NO;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		goto out;
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_msgsnd_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(ipc_msgsnd_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_permission.c
+++ b/security/medusa/l2/acctype_ipc_permission.c
@@ -122,12 +122,12 @@ medusa_answer_t medusa_ipc_permission(struct kern_ipc_perm *ipcp, u32 perms)
 		/* for now, we don't support error codes */
 		return MED_NO;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		goto out;
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_perm_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(ipc_perm_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_semop.c
+++ b/security/medusa/l2/acctype_ipc_semop.c
@@ -61,12 +61,12 @@ medusa_answer_t medusa_ipc_semop(struct kern_ipc_perm *ipcp, struct sembuf *sops
 		/* for now, we don't support error codes */
 		return MED_NO;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		goto out;
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_semop_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(ipc_semop_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_shmat.c
+++ b/security/medusa/l2/acctype_ipc_shmat.c
@@ -53,12 +53,12 @@ medusa_answer_t medusa_ipc_shmat(struct kern_ipc_perm *ipcp, char __user *shmadd
 		/* for now, we don't support error codes */
 		return MED_NO;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		goto out;
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_shmat_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(ipc_shmat_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_link.c
+++ b/security/medusa/l2/acctype_link.c
@@ -36,19 +36,19 @@ medusa_answer_t medusa_link(struct dentry *dentry, const char * newname)
 	if (!dentry || IS_ERR(dentry) || dentry->d_inode == NULL)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0) {
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(dentry->d_inode)))
 	)
 		return MED_NO;
-	if (MEDUSA_MONITORED_ACCESS_O(link_access, &inode_security(dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(link_access, inode_security(dentry->d_inode)))
 		return medusa_do_link(dentry, newname);
 	return MED_OK;
 }

--- a/security/medusa/l2/acctype_lookup.c
+++ b/security/medusa/l2/acctype_lookup.c
@@ -33,16 +33,16 @@ medusa_answer_t medusa_lookup(struct inode *dir, struct dentry **dentry)
 {
 	if (!*dentry || IS_ERR(*dentry) || !(*dentry)->d_inode)
 		return MED_OK;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security((*dentry)->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security((*dentry)->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(*dentry,NULL) <= 0)
 		return MED_OK;
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security((*dentry)->d_inode))))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security((*dentry)->d_inode))))
 		return MED_SKIP;
-	if (MEDUSA_MONITORED_ACCESS_O(lookup_access, &inode_security((*dentry)->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(lookup_access, inode_security((*dentry)->d_inode)))
 		return medusa_do_lookup(*dentry);
 	return MED_OK;
 }

--- a/security/medusa/l2/acctype_mkdir.c
+++ b/security/medusa/l2/acctype_mkdir.c
@@ -38,7 +38,7 @@ medusa_answer_t medusa_mkdir(const struct path *parent, struct dentry *dentry, i
 
 	if (!dentry || IS_ERR(dentry))
 		return MED_OK;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
@@ -46,18 +46,18 @@ medusa_answer_t medusa_mkdir(const struct path *parent, struct dentry *dentry, i
 	//ndcurrent.mnt = NULL;
 	//medusa_get_upper_and_parent(&ndcurrent,&ndupper,&ndparent);
 
-	if (!is_med_magic_valid(&(&inode_security(parent->dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(parent->dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(parent->dentry,parent->mnt) <= 0) {
 		// medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(parent->dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(parent->dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(parent->dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(parent->dentry->d_inode)))
 	) {
 		//medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_NO;
 	}
-	if (MEDUSA_MONITORED_ACCESS_O(mkdir_access, &inode_security(parent->dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(mkdir_access, inode_security(parent->dentry->d_inode)))
 		retval = medusa_do_mkdir(parent->dentry, dentry, mode);
 	else
 		retval = MED_OK;

--- a/security/medusa/l2/acctype_mknod.c
+++ b/security/medusa/l2/acctype_mknod.c
@@ -32,7 +32,7 @@ int __init mknod_acctype_init(void) {
 	return 0;
 }
 
-static medusa_answer_t medusa_do_mknod(struct dentry * parent, struct dentry *dentry, dev_t dev, int mode);
+static medusa_answer_t medusa_do_mknod(struct dentry *parent, struct dentry *dentry, dev_t dev, int mode);
 medusa_answer_t medusa_mknod(struct dentry *dentry, dev_t dev, int mode)
 {
 	struct path ndcurrent, ndupper, ndparent;
@@ -40,7 +40,7 @@ medusa_answer_t medusa_mknod(struct dentry *dentry, dev_t dev, int mode)
 
 	if (!dentry || IS_ERR(dentry))
 		return MED_OK;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
@@ -48,18 +48,18 @@ medusa_answer_t medusa_mknod(struct dentry *dentry, dev_t dev, int mode)
 	ndcurrent.mnt = NULL;
 	medusa_get_upper_and_parent(&ndcurrent,&ndupper,&ndparent);
 
-	if (!is_med_magic_valid(&(&inode_security(ndparent.dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(ndparent.dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(ndparent.dentry,ndparent.mnt) <= 0) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(ndparent.dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(ndparent.dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(ndparent.dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(ndparent.dentry->d_inode)))
 	) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_NO;
 	}
-	if (MEDUSA_MONITORED_ACCESS_O(mknod_access, &inode_security(ndparent.dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(mknod_access, inode_security(ndparent.dentry->d_inode)))
 		retval = medusa_do_mknod(ndparent.dentry, ndupper.dentry, dev, mode);
 	else
 		retval = MED_OK;
@@ -68,7 +68,7 @@ medusa_answer_t medusa_mknod(struct dentry *dentry, dev_t dev, int mode)
 }
 
 /* XXX Don't try to inline this. GCC tries to be too smart about stack. */
-static medusa_answer_t medusa_do_mknod(struct dentry * parent, struct dentry *dentry, dev_t dev, int mode)
+static medusa_answer_t medusa_do_mknod(struct dentry *parent, struct dentry *dentry, dev_t dev, int mode)
 {
 	struct mknod_access access;
 	struct process_kobject process;

--- a/security/medusa/l2/acctype_notify_change.c
+++ b/security/medusa/l2/acctype_notify_change.c
@@ -46,21 +46,21 @@ medusa_answer_t medusa_notify_change(struct dentry *dentry, struct iattr * attr)
 	if (!dentry || IS_ERR(dentry) || dentry->d_inode == NULL)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0)
 		return MED_OK;
 
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(dentry->d_inode)))
 	)
 		return MED_NO;
 	if (!attr)
 		return MED_OK;
-	if (MEDUSA_MONITORED_ACCESS_O(notify_change_access, &inode_security(dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(notify_change_access, inode_security(dentry->d_inode)))
 		return medusa_do_notify_change(dentry, attr);
 	return MED_OK;
 }

--- a/security/medusa/l2/acctype_permission.c
+++ b/security/medusa/l2/acctype_permission.c
@@ -46,28 +46,28 @@ medusa_answer_t medusa_permission(struct inode * inode, int mask)
 	medusa_answer_t retval = MED_YES;
 	struct dentry * dentry;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_YES;
 
 	dentry = d_find_alias(inode);
 	if (!dentry || IS_ERR(dentry))
 		return retval;
-	if (!is_med_magic_valid(&(&inode_security(inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0)
 		goto out_dput;
 	if (
-		!vs_intersects(VSS(&task_security(current)),VS(&inode_security(inode))) ||
+		!vs_intersects(VSS(task_security(current)),VS(inode_security(inode))) ||
 		( (mask & (S_IRUGO | S_IXUGO)) &&
-		  	!vs_intersects(VSR(&task_security(current)),VS(&inode_security(inode))) ) ||
+		  	!vs_intersects(VSR(task_security(current)),VS(inode_security(inode))) ) ||
 		( (mask & S_IWUGO) &&
-		  	!vs_intersects(VSW(&task_security(current)),VS(&inode_security(inode))) )
+		  	!vs_intersects(VSW(task_security(current)),VS(inode_security(inode))) )
 	   ) {
 		retval = -EACCES;
 		goto out_dput;
 	}
 
-	if (MEDUSA_MONITORED_ACCESS_O(permission_access, &inode_security(inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(permission_access, inode_security(inode)))
 		retval = medusa_do_permission(dentry, inode, mask);
 out_dput:
 	dput(dentry);

--- a/security/medusa/l2/acctype_ptrace.c
+++ b/security/medusa/l2/acctype_ptrace.c
@@ -35,18 +35,18 @@ medusa_answer_t medusa_ptrace(struct task_struct * tracer, struct task_struct * 
         /* process_kobject tracer_p is zeroed by process_kern2kobj function */
         /* process_kobject tracee_p is zeroed by process_kern2kobj function */
 
-	if (!is_med_magic_valid(&(&task_security(tracer))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(tracer)->med_object)) &&
 		process_kobj_validate_task(tracer) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(tracee))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(tracee)->med_object)) &&
 		process_kobj_validate_task(tracee) <= 0)
 		return MED_OK;
 
-	if (!vs_intersects(VSS(&task_security(tracer)), VS(&task_security(tracee))) ||
-		!vs_intersects(VSW(&task_security(tracer)), VS(&task_security(tracee))))
+	if (!vs_intersects(VSS(task_security(tracer)), VS(task_security(tracee))) ||
+		!vs_intersects(VSW(task_security(tracer)), VS(task_security(tracee))))
 		return MED_NO;
-	if (MEDUSA_MONITORED_ACCESS_S(ptrace_access, &task_security(tracer))) {
+	if (MEDUSA_MONITORED_ACCESS_S(ptrace_access, task_security(tracer))) {
 		process_kern2kobj(&tracer_p, tracer);
 		process_kern2kobj(&tracee_p, tracee);
 		retval = MED_DECIDE(ptrace_access, &access, &tracer_p, &tracee_p);

--- a/security/medusa/l2/acctype_readlink.c
+++ b/security/medusa/l2/acctype_readlink.c
@@ -35,18 +35,18 @@ medusa_answer_t medusa_readlink(struct dentry *dentry)
 	if (!dentry || IS_ERR(dentry) || dentry->d_inode == NULL)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0) {
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(dentry->d_inode)))
 	)
 		return MED_NO;
-	if (MEDUSA_MONITORED_ACCESS_O(readlink_access, &inode_security(dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(readlink_access, inode_security(dentry->d_inode)))
 		return medusa_do_readlink(dentry);
 	return MED_OK;
 }

--- a/security/medusa/l2/acctype_readwrite.c
+++ b/security/medusa/l2/acctype_readwrite.c
@@ -26,16 +26,16 @@ medusa_answer_t medusa_read(struct file * file)
 	dentry = file->f_path.dentry;
 	if (!dentry || IS_ERR(dentry))
 		return MED_OK;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0)
 		return MED_OK;
 	if (
-		!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSR(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+		!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSR(task_security(current)),VS(inode_security(dentry->d_inode)))
 	   ) {
 		return MED_NO;
 	}
@@ -55,16 +55,16 @@ medusa_answer_t medusa_write(struct file * file)
 	dentry = file->f_path.dentry;
 	if (!dentry || IS_ERR(dentry))
 		return MED_OK;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0)
 		return MED_OK;
 	if (
-		!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+		!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(dentry->d_inode)))
 	   ) {
 		return MED_NO;
 	}

--- a/security/medusa/l2/acctype_rename.c
+++ b/security/medusa/l2/acctype_rename.c
@@ -38,23 +38,23 @@ medusa_answer_t medusa_rename(struct dentry *dentry, const char * newname)
 	if (!dentry || IS_ERR(dentry) || dentry->d_inode == NULL)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0) {
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(dentry->d_inode)))
 	)
 		return MED_NO;
 #warning FIXME - add target directory checking
 	r = MED_OK;
-	if (MEDUSA_MONITORED_ACCESS_O(rename_access, &inode_security(dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(rename_access, inode_security(dentry->d_inode)))
 		r=medusa_do_rename(dentry,newname);
-	med_magic_invalidate(&(&inode_security(dentry->d_inode))->med_object);
+	med_magic_invalidate(&(inode_security(dentry->d_inode)->med_object));
 	return r;
 }
 

--- a/security/medusa/l2/acctype_rmdir.c
+++ b/security/medusa/l2/acctype_rmdir.c
@@ -33,23 +33,23 @@ int __init rmdir_acctype_init(void) {
 static medusa_answer_t medusa_do_rmdir(struct dentry *dentry);
 medusa_answer_t medusa_rmdir(const struct path *dir, struct dentry *dentry)
 {
-	
+
 	if (!dentry || IS_ERR(dir->dentry) || dentry->d_inode == NULL)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0) {
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(dentry->d_inode)))
 	)
 		return MED_NO;
-	if (MEDUSA_MONITORED_ACCESS_O(rmdir_access, &inode_security(dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(rmdir_access, inode_security(dentry->d_inode)))
 		return medusa_do_rmdir(dentry);
 	return MED_OK;
 }

--- a/security/medusa/l2/acctype_sendsig.c
+++ b/security/medusa/l2/acctype_sendsig.c
@@ -59,19 +59,19 @@ medusa_answer_t medusa_sendsig(int sig, struct kernel_siginfo *info, struct task
 			return MED_OK;
 	}
 	*/
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(p))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(p)->med_object)) &&
 		process_kobj_validate_task(p) <= 0)
 		return MED_OK;
 
-	if (!vs_intersects(VSS(&task_security(current)), VS(&task_security(p))) ||
-			!vs_intersects(VSW(&task_security(current)), VS(&task_security(p))))
+	if (!vs_intersects(VSS(task_security(current)), VS(task_security(p))) ||
+			!vs_intersects(VSW(task_security(current)), VS(task_security(p))))
 		return MED_NO;
 
-	if (MEDUSA_MONITORED_ACCESS_S(send_signal, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(send_signal, task_security(current))) {
 		access.signal_number = sig;
 		process_kern2kobj(&sender, current);
 		process_kern2kobj(&receiver, p);

--- a/security/medusa/l2/acctype_setresuid.c
+++ b/security/medusa/l2/acctype_setresuid.c
@@ -38,11 +38,11 @@ medusa_answer_t medusa_setresuid(uid_t ruid, uid_t euid, uid_t suid)
         memset(&access, '\0', sizeof(struct setresuid));
         /* process_kobject process is zeroed by process_kern2kobj function */
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (MEDUSA_MONITORED_ACCESS_S(setresuid, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(setresuid, task_security(current))) {
 		access.ruid = ruid;
 		access.euid = euid;
 		access.suid = suid;

--- a/security/medusa/l2/acctype_sexec.c
+++ b/security/medusa/l2/acctype_sexec.c
@@ -55,15 +55,15 @@ medusa_answer_t medusa_sexec(struct linux_binprm * bprm)
 {
 	medusa_answer_t retval = MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(DENTRY->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(DENTRY->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(DENTRY,bprm->file->f_path.mnt) <= 0)
 		return MED_OK;
 	/* no sense in checking VS here */
-	if (MEDUSA_MONITORED_ACCESS_S(sexec_access, &task_security(current)))
+	if (MEDUSA_MONITORED_ACCESS_S(sexec_access, task_security(current)))
 		retval = medusa_do_sexec(bprm);
 	return retval;
 }

--- a/security/medusa/l2/acctype_socket_accept.c
+++ b/security/medusa/l2/acctype_socket_accept.c
@@ -24,16 +24,16 @@ medusa_answer_t medusa_socket_accept(struct socket *sock, struct socket *newsock
 	struct process_kobject process;
 	struct socket_kobject sock_kobj;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		return MED_YES;
-	if (!is_med_magic_valid(&(&sock_security(sock->sk))->med_object) && socket_kobj_validate(sock) <= 0)
+	if (!is_med_magic_valid(&(sock_security(sock->sk)->med_object)) && socket_kobj_validate(sock) <= 0)
 		return MED_YES;
 
-	if (!vs_intersects(VSS(&task_security(current)),VS(&sock_security(sock->sk))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&sock_security(sock->sk))))
+	if (!vs_intersects(VSS(task_security(current)),VS(sock_security(sock->sk))) ||
+		!vs_intersects(VSW(task_security(current)),VS(sock_security(sock->sk))))
 		return MED_ERR;
 
-	if (MEDUSA_MONITORED_ACCESS_S(socket_accept_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(socket_accept_access, task_security(current))) {
 		socket_kern2kobj(&sock_kobj, sock);
 		process_kern2kobj(&process, current);
 

--- a/security/medusa/l2/acctype_socket_bind.c
+++ b/security/medusa/l2/acctype_socket_bind.c
@@ -29,19 +29,19 @@ medusa_answer_t medusa_socket_bind_security(struct socket *sock, struct socket_b
 {
 	struct process_kobject process;
 	struct socket_kobject sock_kobj;
-	struct medusa_l1_socket_s *sk_sec = &sock_security(sock->sk);
+	struct medusa_l1_socket_s *sk_sec = sock_security(sock->sk);
 	medusa_answer_t retval;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		return MED_YES;
-	if (!is_med_magic_valid(&(&sock_security(sock->sk))->med_object) && socket_kobj_validate(sock) <= 0)
+	if (!is_med_magic_valid(&(sock_security(sock->sk)->med_object)) && socket_kobj_validate(sock) <= 0)
 		return MED_YES;
 
-	if (!vs_intersects(VSS(&task_security(current)),VS(&sock_security(sock->sk))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&sock_security(sock->sk))))
+	if (!vs_intersects(VSS(task_security(current)),VS(sock_security(sock->sk))) ||
+		!vs_intersects(VSW(task_security(current)),VS(sock_security(sock->sk))))
 		return MED_ERR;
 
-	if (MEDUSA_MONITORED_ACCESS_S(socket_bind_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(socket_bind_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		socket_kern2kobj(&sock_kobj, sock);
 		retval = MED_DECIDE(socket_bind_access, access, &process, &sock_kobj);

--- a/security/medusa/l2/acctype_socket_connect.c
+++ b/security/medusa/l2/acctype_socket_connect.c
@@ -32,16 +32,16 @@ medusa_answer_t medusa_socket_connect(struct socket *sock, struct sockaddr *addr
 	struct process_kobject process;
 	struct socket_kobject sock_kobj;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		return MED_YES;
-	if (!is_med_magic_valid(&(&sock_security(sock->sk))->med_object) && socket_kobj_validate(sock) <= 0)
+	if (!is_med_magic_valid(&(sock_security(sock->sk)->med_object)) && socket_kobj_validate(sock) <= 0)
 		return MED_YES;
 
-	if (!vs_intersects(VSS(&task_security(current)),VS(&sock_security(sock->sk))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&sock_security(sock->sk))))
+	if (!vs_intersects(VSS(task_security(current)),VS(sock_security(sock->sk))) ||
+		!vs_intersects(VSW(task_security(current)),VS(sock_security(sock->sk))))
 		return MED_ERR;
 
-	if (MEDUSA_MONITORED_ACCESS_S(socket_connect_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(socket_connect_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		socket_kern2kobj(&sock_kobj, sock);
 		access.family = address->sa_family;

--- a/security/medusa/l2/acctype_socket_create.c
+++ b/security/medusa/l2/acctype_socket_create.c
@@ -28,10 +28,10 @@ medusa_answer_t medusa_socket_create(int family, int type, int protocol)
 	struct socket_create_access access;
 	struct process_kobject process;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (MEDUSA_MONITORED_ACCESS_S(socket_create_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(socket_create_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 
 		memset(&access, '\0', sizeof(struct socket_create_access));

--- a/security/medusa/l2/acctype_socket_listen.c
+++ b/security/medusa/l2/acctype_socket_listen.c
@@ -25,16 +25,16 @@ medusa_answer_t medusa_socket_listen(struct socket *sock, int backlog)
 	struct process_kobject process;
 	struct socket_kobject sock_kobj;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		return MED_YES;
-	if (!is_med_magic_valid(&(&sock_security(sock->sk))->med_object) && socket_kobj_validate(sock) <= 0)
+	if (!is_med_magic_valid(&(sock_security(sock->sk)->med_object)) && socket_kobj_validate(sock) <= 0)
 		return MED_YES;
 
-	if (!vs_intersects(VSS(&task_security(current)),VS(&sock_security(sock->sk))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&sock_security(sock->sk))))
+	if (!vs_intersects(VSS(task_security(current)),VS(sock_security(sock->sk))) ||
+		!vs_intersects(VSW(task_security(current)),VS(sock_security(sock->sk))))
 		return MED_ERR;
 
-	if (MEDUSA_MONITORED_ACCESS_S(socket_listen_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(socket_listen_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		socket_kern2kobj(&sock_kobj, sock);
 		access.backlog = backlog;

--- a/security/medusa/l2/acctype_socket_recvmsg.c
+++ b/security/medusa/l2/acctype_socket_recvmsg.c
@@ -30,19 +30,19 @@ medusa_answer_t medusa_socket_recvmsg(struct socket *sock, struct msghdr *msg, i
 	struct socket_recvmsg_access access;
 	struct process_kobject process;
 	struct socket_kobject sock_kobj;
-	
+
 	if (!address || !sock->sk->sk_family)
 		return MED_YES;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		return MED_YES;
-	if (!is_med_magic_valid(&(&sock_security(sock->sk))->med_object) && socket_kobj_validate(sock) <= 0)
+	if (!is_med_magic_valid(&(sock_security(sock->sk)->med_object)) && socket_kobj_validate(sock) <= 0)
 		return MED_YES;
 
-	if (!vs_intersects(VSS(&task_security(current)),VS(&sock_security(sock->sk))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&sock_security(sock->sk))))
+	if (!vs_intersects(VSS(task_security(current)),VS(sock_security(sock->sk))) ||
+		!vs_intersects(VSW(task_security(current)),VS(sock_security(sock->sk))))
 		return MED_ERR;
 
-	if (MEDUSA_MONITORED_ACCESS_S(socket_recvmsg_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(socket_recvmsg_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		socket_kern2kobj(&sock_kobj, sock);
 		switch(sock->sk->sk_family) {

--- a/security/medusa/l2/acctype_socket_sendmsg.c
+++ b/security/medusa/l2/acctype_socket_sendmsg.c
@@ -30,19 +30,19 @@ medusa_answer_t medusa_socket_sendmsg(struct socket *sock, struct msghdr *msg, i
 	struct socket_sendmsg_access access;
 	struct process_kobject process;
 	struct socket_kobject sock_kobj;
-	
+
 	if (!address || !sock->sk->sk_family)
 		return MED_YES;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		return MED_YES;
-	if (!is_med_magic_valid(&(&sock_security(sock->sk))->med_object) && socket_kobj_validate(sock) <= 0)
+	if (!is_med_magic_valid(&(sock_security(sock->sk)->med_object)) && socket_kobj_validate(sock) <= 0)
 		return MED_YES;
 
-	if (!vs_intersects(VSS(&task_security(current)),VS(&sock_security(sock->sk))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&sock_security(sock->sk))))
+	if (!vs_intersects(VSS(task_security(current)),VS(sock_security(sock->sk))) ||
+		!vs_intersects(VSW(task_security(current)),VS(sock_security(sock->sk))))
 		return MED_ERR;
 
-	if (MEDUSA_MONITORED_ACCESS_S(socket_sendmsg_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(socket_sendmsg_access, task_security(current))) {
 		process_kern2kobj(&process, current);
 		socket_kern2kobj(&sock_kobj, sock);
 		switch(sock->sk->sk_family) {

--- a/security/medusa/l2/acctype_symlink.c
+++ b/security/medusa/l2/acctype_symlink.c
@@ -39,28 +39,28 @@ medusa_answer_t medusa_symlink(struct dentry *dentry, const char * oldname)
 	if (!dentry || IS_ERR(dentry))
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
 	ndcurrent.dentry = dentry;
 	ndcurrent.mnt = NULL;
 	medusa_get_upper_and_parent(&ndcurrent,&ndupper,&ndparent);
-	
+
 	file_kobj_validate_dentry(ndparent.dentry,ndparent.mnt);
 
-	if (!is_med_magic_valid(&(&inode_security(ndparent.dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(ndparent.dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(ndparent.dentry,ndparent.mnt) <= 0) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(ndparent.dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(ndparent.dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(ndparent.dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(ndparent.dentry->d_inode)))
 	) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_NO;
 	}
-	if (MEDUSA_MONITORED_ACCESS_O(symlink_access, &inode_security(ndparent.dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(symlink_access, inode_security(ndparent.dentry->d_inode)))
 		retval = medusa_do_symlink(ndparent.dentry, ndupper.dentry, oldname);
 	else
 		retval = MED_OK;

--- a/security/medusa/l2/acctype_syscall.c
+++ b/security/medusa/l2/acctype_syscall.c
@@ -56,11 +56,11 @@ medusa_answer_t asmlinkage medusa_syscall_i386(
         memset(&access, '\0', sizeof(struct syscall_access));
         /* process_kobject proc is zeroed by process_kern2kobj function */
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (MEDUSA_MONITORED_ACCESS_S(syscall_access, &task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_S(syscall_access, task_security(current))) {
 		access.sysnr = eax;
 		access.arg1 = p1; access.arg2 = p2;
 		access.arg3 = p3; access.arg4 = p4;

--- a/security/medusa/l2/acctype_truncate.c
+++ b/security/medusa/l2/acctype_truncate.c
@@ -35,18 +35,18 @@ medusa_answer_t medusa_truncate(struct dentry *dentry, unsigned long length)
 {
 	if (!dentry || IS_ERR(dentry) || !dentry->d_inode)
 		return MED_OK;
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0)
 		return MED_OK;
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(dentry->d_inode)))
 	)
 		return MED_NO;
-	if (MEDUSA_MONITORED_ACCESS_O(truncate_access, &inode_security(dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(truncate_access, inode_security(dentry->d_inode)))
 		return medusa_do_truncate(dentry, length);
 	return MED_OK;
 }

--- a/security/medusa/l2/acctype_unlink.c
+++ b/security/medusa/l2/acctype_unlink.c
@@ -35,19 +35,19 @@ medusa_answer_t medusa_unlink(struct dentry *dentry)
 	if (!dentry || IS_ERR(dentry) || dentry->d_inode == NULL)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&task_security(current))->med_object) &&
+	if (!is_med_magic_valid(&(task_security(current)->med_object)) &&
 		process_kobj_validate_task(current) <= 0)
 		return MED_OK;
 
-	if (!is_med_magic_valid(&(&inode_security(dentry->d_inode))->med_object) &&
+	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(dentry,NULL) <= 0) {
 		return MED_OK;
 	}
-	if (!vs_intersects(VSS(&task_security(current)),VS(&inode_security(dentry->d_inode))) ||
-		!vs_intersects(VSW(&task_security(current)),VS(&inode_security(dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)),VS(inode_security(dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)),VS(inode_security(dentry->d_inode)))
 	)
 		return MED_NO;
-	if (MEDUSA_MONITORED_ACCESS_O(unlink_access, &inode_security(dentry->d_inode)))
+	if (MEDUSA_MONITORED_ACCESS_O(unlink_access, inode_security(dentry->d_inode)))
 		return medusa_do_unlink(dentry);
 	return MED_OK;
 }

--- a/security/medusa/l2/evtype_getfile.c
+++ b/security/medusa/l2/evtype_getfile.c
@@ -187,11 +187,11 @@ int file_kobj_validate_dentry(struct dentry * dentry, struct vfsmount * mnt)
 	struct medusa_l1_inode_s *ndcurrent_inode;
 	struct medusa_l1_inode_s *ndparent_inode;
 
-	init_med_object(&(&inode_security(dentry->d_inode))->med_object);
+	init_med_object(&(inode_security(dentry->d_inode)->med_object));
 #ifdef CONFIG_MEDUSA_FILE_CAPABILITIES
-	cap_clear(inode_security(dentry->d_inode).pcap);
-	inode_security(dentry->d_inode).icap = CAP_FULL_SET;
-	inode_security(dentry->d_inode).ecap = CAP_FULL_SET;
+	cap_clear(inode_security(dentry->d_inode)->pcap);
+	inode_security(dentry->d_inode)->icap = CAP_FULL_SET;
+	inode_security(dentry->d_inode)->ecap = CAP_FULL_SET;
 #endif
 	ndcurrent.dentry = dentry;
 	ndcurrent.mnt = mnt; /* may be NULL */
@@ -203,22 +203,22 @@ int file_kobj_validate_dentry(struct dentry * dentry, struct vfsmount * mnt)
 	}
 
 	if (ndcurrent.dentry != ndparent.dentry) {
-		if (!is_med_magic_valid(&(&inode_security(ndparent.dentry->d_inode))->med_object) &&
+		if (!is_med_magic_valid(&(inode_security(ndparent.dentry->d_inode)->med_object)) &&
 			file_kobj_validate_dentry(ndparent.dentry, ndparent.mnt) <= 0) {
 			medusa_put_upper_and_parent(&ndupper, &ndparent);
 			return 0;
 		}
 
 		if (!MEDUSA_MONITORED_ACCESS_O(getfile_event,
-					&inode_security(ndparent.dentry->d_inode))) {
-			ndcurrent_inode = &(inode_security(ndcurrent.dentry->d_inode));
-			ndparent_inode = &(inode_security(ndparent.dentry->d_inode));
+					inode_security(ndparent.dentry->d_inode))) {
+			ndcurrent_inode = inode_security(ndcurrent.dentry->d_inode);
+			ndparent_inode = inode_security(ndparent.dentry->d_inode);
 			ndcurrent_inode->med_object = ndparent_inode->med_object;
-			inode_security(ndcurrent.dentry->d_inode).user = inode_security(ndparent.dentry->d_inode).user;
+			inode_security(ndcurrent.dentry->d_inode)->user = inode_security(ndparent.dentry->d_inode)->user;
 #ifdef CONFIG_MEDUSA_FILE_CAPABILITIES
-			inode_security(ndcurrent.dentry->d_inode).icap = inode_security(ndparent.dentry->d_inode).icap;
-			inode_security(ndcurrent.dentry->d_inode).pcap = inode_security(ndparent.dentry->d_inode).pcap;
-			inode_security(ndcurrent.dentry->d_inode).ecap = inode_security(ndparent.dentry->d_inode).ecap;
+			inode_security(ndcurrent.dentry->d_inode)->icap = inode_security(ndparent.dentry->d_inode)->icap;
+			inode_security(ndcurrent.dentry->d_inode)->pcap = inode_security(ndparent.dentry->d_inode)->pcap;
+			inode_security(ndcurrent.dentry->d_inode)->ecap = inode_security(ndparent.dentry->d_inode)->ecap;
 #endif
 			medusa_put_upper_and_parent(&ndupper, &ndparent);
 			return 1;
@@ -230,7 +230,7 @@ int file_kobj_validate_dentry(struct dentry * dentry, struct vfsmount * mnt)
 	if (do_file_kobj_validate_dentry(&ndcurrent, &ndupper, &ndparent)
 			!= MED_ERR) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
-		return is_med_magic_valid(&(&inode_security(ndcurrent.dentry->d_inode))->med_object);
+		return is_med_magic_valid(&(inode_security(ndcurrent.dentry->d_inode)->med_object));
 	}
 	medusa_put_upper_and_parent(&ndupper, &ndparent);
 	return -1;

--- a/security/medusa/l2/evtype_getprocess.c
+++ b/security/medusa/l2/evtype_getprocess.c
@@ -39,10 +39,10 @@ int process_kobj_validate_task(struct task_struct * ts)
         memset(&event, '\0', sizeof(struct getprocess_event));
         /* process_kobject proc is zeroed by process_kern2kobj function */
 
-	init_med_object(&(&task_security(ts))->med_object);
-	init_med_subject(&(&task_security(ts))->med_subject);
+	init_med_object(&(task_security(ts)->med_object));
+	init_med_subject(&(task_security(ts)->med_subject));
 #ifdef CONFIG_MEDUSA_FORCE
-	task_security(ts).force_code = NULL;
+	task_security(ts)->force_code = NULL;
 #endif
 	process_kern2kobj(&proc, ts);
 	retval = MED_DECIDE(getprocess_event, &event, &proc, &proc);

--- a/security/medusa/l2/evtype_getsocket.c
+++ b/security/medusa/l2/evtype_getsocket.c
@@ -25,7 +25,7 @@ medusa_answer_t socket_kobj_validate(struct socket *sock) {
 		return MED_YES;
 	}
 
-	sk_sec = &sock_security(sock->sk);
+	sk_sec = sock_security(sock->sk);
 	init_med_object(&(sk_sec->med_object));
 	socket_kern2kobj(&sock_kobj, sock);
 

--- a/security/medusa/l2/kobject_file.c
+++ b/security/medusa/l2/kobject_file.c
@@ -15,14 +15,14 @@ int file_kobj2kern(struct file_kobject * fk, struct inode * inode)
 	inode->i_mode = fk->mode;
 	inode->i_uid = fk->uid;
 	inode->i_gid = fk->gid;
-	(&inode_security(inode))->med_object = fk->med_object;
-	inode_security(inode).user = fk->user;
+	inode_security(inode)->med_object = fk->med_object;
+	inode_security(inode)->user = fk->user;
 #ifdef CONFIG_MEDUSA_FILE_CAPABILITIES
-	inode_security(inode).ecap = fk->ecap;
-	inode_security(inode).icap = fk->icap;
-	inode_security(inode).pcap = fk->pcap;
+	inode_security(inode)->ecap = fk->ecap;
+	inode_security(inode)->icap = fk->icap;
+	inode_security(inode)->pcap = fk->pcap;
 #endif /* CONFIG_MEDUSA_FILE_CAPABILITIES */
-	med_magic_validate(&(&inode_security(inode))->med_object);
+	med_magic_validate(&(inode_security(inode)->med_object));
 	return 0;
 }
 
@@ -40,12 +40,12 @@ int file_kern2kobj(struct file_kobject * fk, struct inode * inode)
 	fk->uid = inode->i_uid;
 	fk->gid = inode->i_gid;
 	fk->rdev = (inode->i_rdev);
-	fk->med_object = (&inode_security(inode))->med_object;
-	fk->user = inode_security(inode).user;
+	fk->med_object = inode_security(inode)->med_object;
+	fk->user = inode_security(inode)->user;
 #ifdef CONFIG_MEDUSA_FILE_CAPABILITIES
-	fk->ecap = inode_security(inode).ecap;
-	fk->icap = inode_security(inode).icap;
-	fk->pcap = inode_security(inode).pcap;
+	fk->ecap = inode_security(inode)->ecap;
+	fk->icap = inode_security(inode)->icap;
+	fk->pcap = inode_security(inode)->pcap;
 #endif /* CONFIG_MEDUSA_FILE_CAPABILITIES */
 	return 0;
 }
@@ -91,32 +91,32 @@ void file_kobj_live_add(struct inode * ino)
 	struct inode * tmp;
 
 	write_lock(&live_lock);
-	for (tmp = live_inodes; tmp; tmp = inode_security(tmp).next_live)
+	for (tmp = live_inodes; tmp; tmp = inode_security(tmp)->next_live)
 		if (tmp == ino) {
-			inode_security(tmp).use_count++;
+			inode_security(tmp)->use_count++;
 			write_unlock(&live_lock);
 			return;
 		}
-	inode_security(ino).next_live = live_inodes;
-	inode_security(ino).use_count = 1;
+	inode_security(ino)->next_live = live_inodes;
+	inode_security(ino)->use_count = 1;
 	live_inodes = ino;
 	write_unlock(&live_lock);
 }
-void file_kobj_live_remove(struct inode * ino)
+void file_kobj_live_remove(struct inode *ino)
 {
-	struct inode * tmp;
+	struct inode *tmp;
 
 	write_lock(&live_lock);
-	if (--inode_security(ino).use_count)
+	if (--inode_security(ino)->use_count)
 		goto out;
 	if (ino == live_inodes) {
-		live_inodes = inode_security(ino).next_live;
+		live_inodes = inode_security(ino)->next_live;
 		write_unlock(&live_lock);
 		return;
 	}
-	for (tmp = live_inodes; inode_security(tmp).next_live; tmp = inode_security(tmp).next_live)
-		if (inode_security(tmp).next_live == ino) {
-			inode_security(tmp).next_live = inode_security(ino).next_live;
+	for (tmp = live_inodes; inode_security(tmp)->next_live; tmp = inode_security(tmp)->next_live)
+		if (inode_security(tmp)->next_live == ino) {
+			inode_security(tmp)->next_live = inode_security(ino)->next_live;
 			break;
 		}
 out:
@@ -158,7 +158,7 @@ static inline struct inode * __lookup_inode_by_key(struct file_kobject * key_obj
 	struct inode * p;
 
 	read_lock(&live_lock);
-	for (p = live_inodes; p; p = inode_security(p).next_live)
+	for (p = live_inodes; p; p = inode_security(p)->next_live)
 		if (p->i_ino == key_obj->ino)
 			if (p->i_sb->s_dev == key_obj->dev)
 				break;
@@ -191,8 +191,8 @@ static void file_unmonitor(struct medusa_kobject_s * kobj)
 
 	p = __lookup_inode_by_key((struct file_kobject *)kobj);
 	if (p) {
-		unmonitor_med_object(&(&inode_security(p))->med_object);
-		med_magic_validate(&(&inode_security(p))->med_object);
+		unmonitor_med_object(&(inode_security(p)->med_object));
+		med_magic_validate(&(inode_security(p)->med_object));
 	}
 	__unlookup();
 }

--- a/security/medusa/l2/kobject_file.h
+++ b/security/medusa/l2/kobject_file.h
@@ -22,7 +22,7 @@
 #include <linux/medusa/l1/file_handlers.h>
 #include <linux/medusa/l1/inode.h>
 
-#define inode_security(inode) (*(struct medusa_l1_inode_s*)(inode->i_security))
+#define inode_security(inode) ((struct medusa_l1_inode_s*)(inode->i_security))
 
 struct file_kobject { /* was: m_inode_inf */
 /*

--- a/security/medusa/l2/kobject_fuck.c
+++ b/security/medusa/l2/kobject_fuck.c
@@ -77,8 +77,8 @@ int validate_fuck(const struct path* fuck_path) {
 		med_pr_info("medusa: empty inode\n");
 		goto out;
 	}
-		
-	if (unlikely(hash_empty(inode_security(fuck_inode).fuck)))
+
+	if (unlikely(hash_empty(inode_security(fuck_inode)->fuck)))
 		goto out;
 
 	buf = (char *) kmalloc(sizeof(char) * (PATH_MAX + 1), GFP_KERNEL);
@@ -93,7 +93,7 @@ int validate_fuck(const struct path* fuck_path) {
 	}
 
 	hash = hash_function(accessed_path);
-	if (likely(get_from_hash(accessed_path, hash, &inode_security(fuck_inode)) == NULL)) {
+	if (likely(get_from_hash(accessed_path, hash, inode_security(fuck_inode)) == NULL)) {
 		med_pr_notice("VALIDATE_FUCK: denied path (not defined in allowed path list)\n");
 		ret = -EPERM;
 	}
@@ -107,7 +107,7 @@ out:
 int validate_fuck_link(struct dentry *old_dentry) {
 	struct inode *fuck_inode = old_dentry->d_inode;
 	//if inode has no protected paths defined, allow hard link alse deny
-	if(hash_empty(inode_security(fuck_inode).fuck))
+	if(hash_empty(inode_security(fuck_inode)->fuck))
 		return 0;
 	return -EPERM;
 }
@@ -182,10 +182,10 @@ static medusa_answer_t fuck_update(struct medusa_kobject_s * kobj)
 
 		/* don't check for duplicity in hash table
 		   is up to admin do not add the same 'path' more than once */
-		hash_add(inode_security(fuck_inode).fuck, &fuck_path->list, hash);
+		hash_add(inode_security(fuck_inode)->fuck, &fuck_path->list, hash);
 	} else if (strcmp(fkobj->action, "remove") == 0) {
 		/* remove non-existing path in hash table is ok */
-		if ((fuck_path = get_from_hash(fkobj->path, hash, &inode_security(fuck_inode))) == NULL)
+		if ((fuck_path = get_from_hash(fkobj->path, hash, inode_security(fuck_inode))) == NULL)
 			goto out;
 		hash_del(&fuck_path->list);
 		kfree(fuck_path);

--- a/security/medusa/l2/kobject_fuck.h
+++ b/security/medusa/l2/kobject_fuck.h
@@ -9,8 +9,7 @@
 #include <linux/errno.h>
 #include <linux/medusa/l3/registry.h>
 #include <linux/medusa/l1/inode.h>
-
-#define inode_security(inode) (*(struct medusa_l1_inode_s*)(inode->i_security))
+#include "kobject_file.h"
 
 int validate_fuck_link(struct dentry *old_dentry);
 int validate_fuck(const struct path *fuck_path);

--- a/security/medusa/l2/kobject_ipc.h
+++ b/security/medusa/l2/kobject_ipc.h
@@ -8,7 +8,7 @@
 #include <linux/medusa/l3/constants.h>
 #include <linux/medusa/l1/ipc.h>
 
-#define ipc_security(ipc) ((struct medusa_l1_ipc_s*)(ipcp->security))
+#define ipc_security(ipc) ((struct medusa_l1_ipc_s*)(ipc->security))
 
 /*
  * medusa_ipc_perm - struct holding relevant entries from 'kern_ipc_perm' (see linux/ipc.h)

--- a/security/medusa/l2/kobject_process.h
+++ b/security/medusa/l2/kobject_process.h
@@ -16,7 +16,7 @@
 #include <linux/medusa/l1/task.h>
 #include <linux/medusa/l1/process_handlers.h>
 
-#define task_security(task) (*((struct medusa_l1_task_s*)(task->security)))
+#define task_security(task) ((struct medusa_l1_task_s*)(task->security))
 #define task_suid(task) (task_cred_xxx((task), suid))
 #define task_fsuid(task) (task_cred_xxx((task), fsuid))
 #define task_gid(task) (task_cred_xxx((task), gid))

--- a/security/medusa/l2/kobject_socket.c
+++ b/security/medusa/l2/kobject_socket.c
@@ -17,7 +17,7 @@ MED_ATTRS(socket_kobject) {
 
 int socket_kobj2kern(struct socket_kobject * sock_kobj, struct socket * sock)
 {
-	struct medusa_l1_socket_s *sk_sec = &sock_security(sock->sk);
+	struct medusa_l1_socket_s *sk_sec = sock_security(sock->sk);
 	sock_kobj->med_object = sk_sec->med_object;
 	return 0;
 }
@@ -25,7 +25,7 @@ int socket_kobj2kern(struct socket_kobject * sock_kobj, struct socket * sock)
 int socket_kern2kobj(struct socket_kobject * sock_kobj, struct socket * sock)
 {
 	struct inode *inode = SOCK_INODE(sock);
-	struct medusa_l1_socket_s *sk_sec = &sock_security(sock->sk);
+	struct medusa_l1_socket_s *sk_sec = sock_security(sock->sk);
 
 	sock_kobj->dev = inode->i_sb->s_dev;
 	sock_kobj->ino = inode->i_ino;

--- a/security/medusa/l2/kobject_socket.h
+++ b/security/medusa/l2/kobject_socket.h
@@ -13,7 +13,7 @@
 #include <linux/medusa/l3/registry.h>
 #include "../../fs/internal.h" // For user_get_super()
 
-#define sock_security(sk) (*(struct medusa_l1_socket_s*)(sk->sk_security))
+#define sock_security(sk) ((struct medusa_l1_socket_s*)(sk->sk_security))
 
 struct med_inet6_addr_i {
 	__be16 port;


### PR DESCRIPTION
This will improve readability as I could removed a lot of & symbols.