### PR TITLE
Refactoring of registry.c in L3 + small corrections in code styling

### DIFF
--- a/include/linux/medusa/l3/registry.h
+++ b/include/linux/medusa/l3/registry.h
@@ -17,9 +17,9 @@
 extern int authserver_magic; /* to be checked against magic in objects */
 
 /* interface to L2 */
-extern int med_register_kclass(struct medusa_kclass_s * ptr);
-extern int med_unlink_kclass(struct medusa_kclass_s * ptr);
-extern int med_unregister_kclass(struct medusa_kclass_s * ptr);
+extern int med_register_kclass(struct medusa_kclass_s *med_kclass);
+extern int med_unlink_kclass(struct medusa_kclass_s *med_kclass);
+extern int med_unregister_kclass(struct medusa_kclass_s *med_kclass);
 #define MED_REGISTER_KCLASS(structname) \
 		med_register_kclass(&MED_KCLASSOF(structname))
 #define MED_UNLINK_KCLASS(structname) \
@@ -27,8 +27,8 @@ extern int med_unregister_kclass(struct medusa_kclass_s * ptr);
 #define MED_UNREGISTER_KCLASS(structname) \
 		med_unregister_kclass(&MED_KCLASSOF(structname))
 
-extern int med_register_evtype(struct medusa_evtype_s * ptr, int flags);
-extern void med_unregister_evtype(struct medusa_evtype_s * ptr);
+extern int med_register_evtype(struct medusa_evtype_s *med_evtype, int flags);
+extern void med_unregister_evtype(struct medusa_evtype_s *med_evtype);
 #define MED_REGISTER_EVTYPE(structname,flags) \
 		med_register_evtype(&MED_EVTYPEOF(structname),flags)
 #define MED_UNREGISTER_EVTYPE(structname) \
@@ -44,22 +44,20 @@ extern void med_unregister_evtype(struct medusa_evtype_s * ptr);
  *	MEDUSA_ACCTYPE_TRIGGEREDATSUBJECT (the ... subject)
  */
 
-extern medusa_answer_t med_decide(struct medusa_evtype_s * acctype, void * access, void * o1, void * o2);
+extern medusa_answer_t med_decide(struct medusa_evtype_s *acctype, void * access, void *o1, void *o2);
 #define MED_DECIDE(structname,arg1,arg2,arg3) \
 		med_decide(&MED_EVTYPEOF(structname), arg1, arg2, arg3)
 
 /* interface to L2 and L4 */
-extern void med_get_kclass(struct medusa_kclass_s * ptr);
-extern void med_put_kclass(struct medusa_kclass_s * ptr);
-extern struct medusa_kclass_s * med_get_kclass_by_name(char * name);
-extern struct medusa_kclass_s * med_get_kclass_by_cinfo(cinfo_t cinfo);
-extern struct medusa_kclass_s * med_get_kclass_by_pointer(struct medusa_kclass_s * ptr);
-extern struct medusa_authserver_s * med_get_authserver(void);
-extern void med_put_authserver(struct medusa_authserver_s * ptr);
+extern void med_get_kclass(struct medusa_kclass_s *med_kclass);
+extern void med_put_kclass(struct medusa_kclass_s *med_kclass);
+extern struct medusa_kclass_s *med_get_kclass_by_pointer(struct medusa_kclass_s *med_kclass);
+extern struct medusa_authserver_s *med_get_authserver(void);
+extern void med_put_authserver(struct medusa_authserver_s *med_authserver);
 
 /* interface to L4 */
-extern int med_register_authserver(struct medusa_authserver_s * ptr);
-extern void med_unregister_authserver(struct medusa_authserver_s * ptr);
+extern int med_register_authserver(struct medusa_authserver_s *med_authserver);
+extern void med_unregister_authserver(struct medusa_authserver_s *med_authserver);
 #define MED_REGISTER_AUTHSERVER(structname) \
 		med_register_authserver(&structname)
 #define MED_UNREGISTER_AUTHSERVER(structname) \

--- a/security/medusa/l2/kobject_cstrmem.c
+++ b/security/medusa/l2/kobject_cstrmem.c
@@ -4,8 +4,8 @@
  * `fetch'. Kobjects of this type are never used as a subject or object of any
  * `access' (and thus they don't need to contain object or subject vars).
  *
- * This is just slightly modified kobject_memory.c with 'update' method removed 
- * and updated returned object size 
+ * This is just slightly modified kobject_memory.c with 'update' method removed
+ * and updated returned object size
  */
 
 /* And as it isn't really necessary, it's a perfect example of loadable L2
@@ -21,8 +21,8 @@
 #include <linux/medusa/l3/registry.h>
 
 struct cstrmem_kobject {
-	pid_t  pid;		/* pid of process to read/write */
-	void * address;		/* address for read/write */
+	pid_t pid;		/* pid of process to read/write */
+	void *address;		/* address for read/write */
 	size_t size;		/* size of the data, must be <= 512 */
 	ssize_t retval;		/* either the size of data, or errno */
 	char data[512];		/* data to be written, or data read */
@@ -37,7 +37,7 @@ MED_ATTRS(cstrmem_kobject) {
 	MED_ATTR_END
 };
 
-static struct medusa_kobject_s * cstrmem_fetch(struct medusa_kobject_s *);
+static struct medusa_kobject_s *cstrmem_fetch(struct medusa_kobject_s *);
 
 MED_KCLASS(cstrmem_kobject) {
 	MEDUSA_KCLASS_HEADER(cstrmem_kobject),
@@ -48,8 +48,6 @@ MED_KCLASS(cstrmem_kobject) {
 	NULL,		/* update kobject */
 	NULL,		/* unmonitor */
 };
-
-/* module stuff */
 
 #ifdef MODULE
 static int cstrmem_kobject_unload_check(void) __exit;
@@ -67,53 +65,48 @@ int __init cstrmem_kobject_init(void)
 /* After this is called, and returns 0, cstrmem_kobject_rmmod should be. */
 static int __exit cstrmem_kobject_unload_check(void)
 {
-	if (med_unlink_kclass(&MED_KCLASSOF(cstrmem_kobject)) != MED_ALLOW)
+	if (MED_UNLINK_KCLASS(cstrmem_kobject) != 0)
 		return -EBUSY;
 	return 0;
 }
 
 void __exit cstrmem_kobject_rmmod(void)
 {
-	med_unregister_kclass(&MED_KCLASSOF(cstrmem_kobject));
+	MED_UNREGISTER_KCLASS(cstrmem_kobject);
 }
 
 module_init(cstrmem_kobject_init);
 module_exit(cstrmem_kobject_rmmod);
+
 /* quoting the comment in module.h:
  *
  * There are dual licensed components, but when running with Linux it is the
- * GPL that is relevant so this is a non issue. 
+ * GPL that is relevant so this is a non issue.
  */
 MODULE_LICENSE("GPL");
 
-/* implementation */
-
-// static struct cstrmem_kobject storage;
-
-static struct medusa_kobject_s * cstrmem_fetch(struct medusa_kobject_s * key_obj)
+static struct medusa_kobject_s *cstrmem_fetch(struct medusa_kobject_s *key_obj)
 {
 	int i, ret;
-	struct task_struct * p;
+	struct task_struct *p;
 	struct cstrmem_kobject* kobj = (struct cstrmem_kobject*) key_obj;
 
 	rcu_read_lock();
-	//p = find_task_by_pid(storage.pid);
 	p = pid_task(find_vpid(kobj->pid), PIDTYPE_PID);
 	if (p) {
 		get_task_struct(p);
 		rcu_read_unlock();
 		ret = access_process_vm(p, (unsigned long)kobj->address, kobj->data, kobj->size, 0);
-		/* TODO: here it should count characters until the first #0 found in (0,size) boundary */
+
+		/* TODO: refactor to something more .. obvious
+		 * TODO: here it should count characters until the first #0 found in (0,size) boundary */
 		for (i = 0; (i < kobj->size) && (((char*)kobj->data)[i]); i++);
-		/* end - hope it works... */
-		//free_task_struct(p);
+
 		free_task(p);
-		/* original: storage.retval = ret; */
 		kobj->retval = i;
 		return key_obj;
 	}
 	rcu_read_unlock();
-	/* subject to change */
 	kobj->retval = -ESRCH;
 	return key_obj;
 }

--- a/security/medusa/l2/kobject_cstrmem.c
+++ b/security/medusa/l2/kobject_cstrmem.c
@@ -99,6 +99,7 @@ static struct medusa_kobject_s *cstrmem_fetch(struct medusa_kobject_s *key_obj)
 		ret = access_process_vm(p, (unsigned long)kobj->address, kobj->data, kobj->size, 0);
 
 		/* TODO: refactor to something more .. obvious
+		 * see https://www.kernel.org/doc/htmldocs/kernel-api/API-strnlen.html
 		 * TODO: here it should count characters until the first #0 found in (0,size) boundary */
 		for (i = 0; (i < kobj->size) && (((char*)kobj->data)[i]); i++);
 

--- a/security/medusa/l2/kobject_memory.c
+++ b/security/medusa/l2/kobject_memory.c
@@ -19,7 +19,7 @@
 #include <linux/medusa/l3/registry.h>
 
 struct memory_kobject {
-	pid_t  pid;		/* pid of process to read/write */
+	pid_t pid;		/* pid of process to read/write */
 	void *address;		/* address for read/write */
 	size_t size;		/* size of the data, must be <= 512 */
 	ssize_t retval;		/* either the size of data, or errno */
@@ -66,28 +66,25 @@ int __init memory_kobject_init(void)
 /* After this is called, and returns 0, memory_kobject_rmmod should be. */
 static int __exit memory_kobject_unload_check(void)
 {
-	if (med_unlink_kclass(&MED_KCLASSOF(memory_kobject)) != 0)
+	if (MED_UNLINK_KCLASS(memory_kobject) != 0)
 		return -EBUSY;
 	return 0;
 }
 
 void __exit memory_kobject_rmmod(void)
 {
-	med_unregister_kclass(&MED_KCLASSOF(memory_kobject));
+	MED_UNREGISTER_KCLASS(memory_kobject);
 }
 
 module_init(memory_kobject_init);
 module_exit(memory_kobject_rmmod);
+
 /* quoting the comment in module.h:
  *
  * There are dual licensed components, but when running with Linux it is the
  * GPL that is relevant so this is a non issue.
  */
 MODULE_LICENSE("GPL");
-
-/* implementation */
-
-// static struct memory_kobject storage;
 
 static struct medusa_kobject_s *memory_fetch(struct medusa_kobject_s *key_obj)
 {
@@ -96,19 +93,16 @@ static struct medusa_kobject_s *memory_fetch(struct medusa_kobject_s *key_obj)
 	struct memory_kobject* kobj = (struct memory_kobject *) key_obj;
 
 	rcu_read_lock();
-	//p = find_task_by_pid(storage.pid);
 	p = pid_task(find_vpid(kobj->pid), PIDTYPE_PID);
 	if (p) {
 		get_task_struct(p);
 		rcu_read_unlock();
 		ret = access_process_vm(p, (unsigned long)kobj->address, kobj->data, kobj->size, 0);
-		//free_task_struct(p);
 		free_task(p);
 		kobj->retval = ret;
 		return key_obj;
 	}
 	rcu_read_unlock();
-	/* subject to change */
 	kobj->retval = -ESRCH;
 	return key_obj;
 }
@@ -119,7 +113,6 @@ static medusa_answer_t memory_update(struct medusa_kobject_s *kobj)
 	struct task_struct *p;
 
 	rcu_read_lock();
-	//p = find_task_by_pid(((struct memory_kobject *) kobj)->pid);
 	p = pid_task(find_vpid(((struct memory_kobject *) kobj)->pid), PIDTYPE_PID);
 	if (p) {
 		get_task_struct(p);
@@ -130,7 +123,6 @@ static medusa_answer_t memory_update(struct medusa_kobject_s *kobj)
 			((struct memory_kobject *) kobj)->data,
 			((struct memory_kobject *) kobj)->size,
 			1);
-		//free_task_struct(p);
 		free_task(p);
 		return (ret == ((struct memory_kobject *) kobj)->size) ?
 			MED_ALLOW : MED_ERR;

--- a/security/medusa/l2/kobject_printk.c
+++ b/security/medusa/l2/kobject_printk.c
@@ -7,7 +7,6 @@
 #include <linux/medusa/l3/registry.h>
 
 struct printk_kobject {
-	/* int loglevel; */ /* TODO: add loglevels some day */
 	char message[512];
 };
 
@@ -16,11 +15,11 @@ MED_ATTRS(printk_kobject) {
 	MED_ATTR_END
 };
 
-static struct medusa_kobject_s * printk_fetch(struct medusa_kobject_s * key_obj)
+static struct medusa_kobject_s *printk_fetch(struct medusa_kobject_s *key_obj)
 {
 	return NULL;
 }
-static medusa_answer_t printk_update(struct medusa_kobject_s * kobj)
+static medusa_answer_t printk_update(struct medusa_kobject_s *kobj)
 {
 	((struct printk_kobject *) kobj)->message[sizeof(((struct printk_kobject *) kobj)->message)-1] = '\0';
 	med_pr_debug("%s",((struct printk_kobject *) kobj)->message);
@@ -54,14 +53,14 @@ int __init printk_kobject_init(void) {
 /* After this is called, and returns 0, printk_kobject_rmmod should be. */
 static int __exit printk_kobject_unload_check(void)
 {
-	if (med_unlink_kclass(&MED_KCLASSOF(printk_kobject)) != MED_ALLOW)
+	if (MED_UNLINK_KCLASS(printk_kobject) != 0)
 		return -EBUSY;
 	return 0;
 }
 
 void __exit printk_kobject_rmmod(void)
 {
-	med_unregister_kclass(&MED_KCLASSOF(printk_kobject));
+	MED_UNREGISTER_KCLASS(printk_kobject);
 }
 
 module_init(printk_kobject_init);

--- a/security/medusa/l3/med_l3_init.c
+++ b/security/medusa/l3/med_l3_init.c
@@ -6,16 +6,16 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- * 
+ *
  *
  * This is the main file of L3. It calls initialization routines of
  * l3 related code, and it also exports some symbols. What a surprise,
@@ -26,15 +26,9 @@
 #include <linux/medusa/l3/arch.h>
 #include <linux/medusa/l3/registry.h>
 
-// EXPORT_SYMBOL(kclasses);
-// EXPORT_SYMBOL(evtypes);
-// EXPORT_SYMBOL(authserver);
-
 EXPORT_SYMBOL(med_register_kclass);
 EXPORT_SYMBOL(med_unregister_kclass);
 EXPORT_SYMBOL(med_get_kclass);
-EXPORT_SYMBOL(med_get_kclass_by_name);
-EXPORT_SYMBOL(med_get_kclass_by_cinfo);
 EXPORT_SYMBOL(med_get_kclass_by_pointer);
 EXPORT_SYMBOL(med_put_kclass);
 EXPORT_SYMBOL(med_unlink_kclass);

--- a/security/medusa/l3/registry.c
+++ b/security/medusa/l3/registry.c
@@ -5,11 +5,11 @@
 /* nesting as follows: registry_lock is outer, usecount_lock is inner. */
 
 MED_LOCK_DATA(registry_lock); /* the linked list lock */
- static MED_LOCK_DATA(usecount_lock); /* the lock for modifying use-count */
-  struct medusa_kclass_s * kclasses = NULL;
-  struct medusa_evtype_s * evtypes = NULL;
-  struct medusa_authserver_s * authserver = NULL;
- int medusa_authserver_magic = 1; /* the 'version' of authserver */
+static MED_LOCK_DATA(usecount_lock); /* the lock for modifying use-count */
+struct medusa_kclass_s *kclasses = NULL;
+struct medusa_evtype_s *evtypes = NULL;
+struct medusa_authserver_s *authserver = NULL;
+int medusa_authserver_magic = 1; /* the 'version' of authserver */
 /* WARNING! medusa_authserver_magic is not locked, nor atomic type,
  * because we want to have as much portable (and easy and fast) code
  * as possible. thus we must change its value BEFORE modifying authserver,
@@ -17,106 +17,50 @@ MED_LOCK_DATA(registry_lock); /* the linked list lock */
  * hopefully contains some kind of such barrier ;).
  */
 
-static int mystrcmp(char * p1, char * p2)
-{
-	while (*p1) {
-		if (*p2 != *p1)
-			return *p1 - *p2;
-		p1++; p2++;
-	}
-	return -*p2;
-}
-
 /**
  * med_get_kclass - lock the kclass by incrementing its use-count.
- * @ptr: pointer to the kclass to lock
+ * @med_kclass: pointer to the kclass to lock
  *
  * This increments the use-count; works great even if you want to sleep.
  * when calling this function, the use-count must already be non-zero.
  */
-void med_get_kclass(struct medusa_kclass_s * ptr)
+void med_get_kclass(struct medusa_kclass_s *med_kclass)
 {
 	MED_LOCK_W(usecount_lock);
-	ptr->use_count++;
+	med_kclass->use_count++;
 	MED_UNLOCK_W(usecount_lock);
 }
 
 /**
  * med_put_kclass - unlock the kclass by decrementing its use-count.
- * @ptr: pointer to the kclass to unlock
+ * @med_kclass: pointer to the kclass to unlock
  *
  * This decrements the use-count. Note that it does nothing special when
  * the use-count goes to zero. Someone still may find the kclass in the
  * linked list and claim it by using med_get_kclass.
  */
-void med_put_kclass(struct medusa_kclass_s * ptr)
+void med_put_kclass(struct medusa_kclass_s *med_kclass)
 {
 	MED_LOCK_W(usecount_lock);
-	if (ptr->use_count) /* sanity check only */
-		ptr->use_count--;
+	if (med_kclass->use_count > 0) /* sanity check only */
+		med_kclass->use_count--;
 	MED_UNLOCK_W(usecount_lock);
 }
 
 /**
- * med_get_kclass_by_name - find a kclass and return get-kclassed refference.
- * @name: name of the kclass to find
- *
- * It may return NULL on failure; caller must verify this each time.
- */
-struct medusa_kclass_s * med_get_kclass_by_name(char * name)
-{
-	struct medusa_kclass_s * tmp;
-
-	MED_LOCK_R(registry_lock);
-	for (tmp = kclasses; tmp; tmp = tmp->next)
-		if (!mystrcmp(name, tmp->name)) {
-			MED_LOCK_W(usecount_lock);
-			tmp->use_count++;
-			MED_UNLOCK_W(usecount_lock);
-			break;
-		}
-	MED_UNLOCK_R(registry_lock);
-	return tmp;
-}
-
-/**
- * med_get_kclass_by_cinfo - find a kclass and return get-kclassed refference.
- * @cinfo: cinfo of the kclass to find
- *
- * It may return NULL on failure; caller must verify this each time.
- */
-struct medusa_kclass_s * med_get_kclass_by_cinfo(cinfo_t cinfo)
-{
-	struct medusa_kclass_s * tmp;
-
-	MED_LOCK_R(registry_lock);
-	for (tmp = kclasses; tmp; tmp = tmp->next)
-		if (cinfo == tmp->cinfo) {
-			MED_LOCK_W(usecount_lock);
-			tmp->use_count++;
-			MED_UNLOCK_W(usecount_lock);
-			break;
-		}
-	MED_UNLOCK_R(registry_lock);
-	return tmp;
-}
-
-/**
  * med_get_kclass_by_pointer - find a kclass and return get-kclassed refference.
- * @ptr: unsafe pointer to the kclass to find
+ * @med_kclass: unsafe pointer to the kclass to find
  *
  * It may return NULL on failure; caller must verify this each time.
  */
-struct medusa_kclass_s * med_get_kclass_by_pointer(struct medusa_kclass_s * ptr)
+struct medusa_kclass_s *med_get_kclass_by_pointer(struct medusa_kclass_s *med_kclass)
 {
 	struct medusa_kclass_s * tmp;
 
 	MED_LOCK_R(registry_lock);
 	for (tmp = kclasses; tmp; tmp = tmp->next)
-		if (ptr == tmp) {
-			MED_LOCK_W(usecount_lock);
-			tmp->use_count++;
-			MED_UNLOCK_W(usecount_lock);
+		if (med_kclass == tmp) {
+			med_get_kclass(med_kclass);
 			break;
 		}
 	MED_UNLOCK_R(registry_lock);
@@ -125,7 +69,7 @@ struct medusa_kclass_s * med_get_kclass_by_pointer(struct medusa_kclass_s * ptr)
 
 /**
  * med_unlink_kclass - unlink the kclass from all L3 lists
- * @ptr: kclass to unlink
+ * @med_kclass: kclass to unlink
  *
  * This is called with use-count=0 to remove the kclass from L3
  * lists. It may be called with all kinds of locks held, and thus
@@ -147,26 +91,43 @@ struct medusa_kclass_s * med_get_kclass_by_pointer(struct medusa_kclass_s * ptr)
  * med_unregister_kclass soon.
  */
 
-int med_unlink_kclass(struct medusa_kclass_s * ptr)
+int _med_unlink_kclass(struct medusa_kclass_s *med_kclass)
 {
-	int retval = 0;
-	struct medusa_kclass_s * tmp;
+	struct medusa_kclass_s *pos, *prev;
+
+	if (med_kclass == kclasses) {
+		kclasses = med_kclass->next;
+		return 0;
+	}
+
+	for (prev = kclasses, pos = kclasses->next; pos != NULL; prev = pos, pos = pos->next) {
+		if (pos == med_kclass) {
+			prev->next = pos->next;
+			return 0;
+		}
+	}
+
+	med_pr_warn("Failed to unlink kclass '%s' - not found", med_kclass->name);
+	return -1;
+}
+
+int med_unlink_kclass(struct medusa_kclass_s *med_kclass)
+{
+	int retval;
 
 	MED_LOCK_W(registry_lock);
 	MED_LOCK_R(usecount_lock);
-	if (!ptr->use_count) {
-		if (ptr == kclasses)
-			kclasses = ptr->next;
-		else
-			for (tmp = kclasses; tmp; tmp = tmp->next)
-				if (tmp->next == ptr) {
-					tmp->next = tmp->next->next;
-					break;
-				}
-		/* TODO: verify whether we found it! */
-		ptr->next = NULL;
-	} else
+	if (med_kclass->use_count == 0) {
+		retval = _med_unlink_kclass(med_kclass);
+		if (retval != -1) {
+			med_kclass->next = NULL;
+		}
+	} else {
+		med_pr_warn("Failed to unlink kclass '%s' because the use count is %d", med_kclass->name,
+										med_kclass->use_count);
 		retval = -1;
+	}
+
 	MED_UNLOCK_R(usecount_lock);
 	MED_UNLOCK_W(registry_lock);
 	return retval;
@@ -183,12 +144,12 @@ int med_unlink_kclass(struct medusa_kclass_s * ptr)
  *
  * The callbacks called from here may sleep.
  */
-int med_unregister_kclass(struct medusa_kclass_s * ptr)
+int med_unregister_kclass(struct medusa_kclass_s *med_kclass)
 {
-	med_pr_info("Unregistering kclass %s\n", ptr->name);
+	med_pr_info("Unregistering kclass %s\n", med_kclass->name);
 	MED_LOCK_R(registry_lock);
 	MED_LOCK_R(usecount_lock);
-	if (ptr->use_count || ptr->next) { /* useless sanity check */
+	if (med_kclass->use_count != 0 || med_kclass->next) { /* useless sanity check */
 		med_pr_crit("A fatal ERROR has occured; expect system crash. If you're removing a file-related kclass, press reset. Otherwise save now.\n");
 		MED_UNLOCK_R(usecount_lock);
 		MED_UNLOCK_R(registry_lock);
@@ -197,28 +158,28 @@ int med_unregister_kclass(struct medusa_kclass_s * ptr)
 	MED_UNLOCK_R(usecount_lock);
 	MED_UNLOCK_R(registry_lock);
 	if (authserver && authserver->del_kclass)
-		authserver->del_kclass(ptr);
+		authserver->del_kclass(med_kclass);
 	/* FIXME: this isn't safe. add use-count to authserver too... */
 	return 0;
 }
 
 /**
  * med_register_kclass - register a kclass of k-objects and notify the authserver
- * @ptr: pointer to the kclass to register
+ * @med_kclass: pointer to the kclass to register
  *
  * The authserver call must be in lock or a semaphore - we promised
  * that in authserver.h. :)
  */
-int med_register_kclass(struct medusa_kclass_s * ptr)
+int med_register_kclass(struct medusa_kclass_s *med_kclass)
 {
-	struct medusa_kclass_s * p;
+	struct medusa_kclass_s *p;
 
-	ptr->name[MEDUSA_KCLASSNAME_MAX-1] = '\0';
-	med_pr_info("Registering kclass %s\n", ptr->name);
+	med_kclass->name[MEDUSA_KCLASSNAME_MAX-1] = '\0';
+	med_pr_info("Registering kclass %s\n", med_kclass->name);
 	MED_LOCK_W(registry_lock);
-	for (p=kclasses; p; p=p->next)
-		if (ptr==p || !mystrcmp(p->name, ptr->name)) {
-			med_pr_err("Error: such kclass already exists.\n");
+	for (p = kclasses; p; p = p->next)
+		if (med_kclass == p) {
+			med_pr_err("Error: '%s' kclass already exists.\n", med_kclass->name);
 			MED_UNLOCK_W(registry_lock);
 			return -1;
 		}
@@ -226,104 +187,108 @@ int med_register_kclass(struct medusa_kclass_s * ptr)
 	 * able to find the entry before it's in the linked list.
 	 * we set use-count to 1, and decrement it soon hereafter.
 	 */
-	ptr->use_count = 1;
-	ptr->next = kclasses;
-	kclasses = ptr;
+	med_kclass->use_count = 1;
+	med_kclass->next = kclasses;
+	kclasses = med_kclass;
 	MED_UNLOCK_W(registry_lock);
 	if (authserver && authserver->add_kclass)
-		authserver->add_kclass(ptr); /* TODO: some day, check the return value */
-	med_put_kclass(ptr);
+		authserver->add_kclass(med_kclass); /* TODO: some day, check the return value */
+	med_put_kclass(med_kclass);
 	return 0;
 }
 
 /**
  * med_register_evtype - register an event type and notify the authserver.
- * @ptr: pointer to the event type to register
+ * @med_evtype: pointer to the event type to register
  *
  * The event type must be prepared by l2 routines to contain pointers to
  * all related kclasses of k-objects.
  */
-int med_register_evtype(struct medusa_evtype_s * ptr, int flags)
+int med_register_evtype(struct medusa_evtype_s *med_evtype, int flags)
 {
-	struct medusa_evtype_s * p;
+	struct medusa_evtype_s *p;
 
-	ptr->name[MEDUSA_EVNAME_MAX-1] = '\0';
-	ptr->arg_name[0][MEDUSA_ATTRNAME_MAX-1] = '\0';
-	ptr->arg_name[1][MEDUSA_ATTRNAME_MAX-1] = '\0';
-	/* TODO: check whether kclasses are registered, maybe register automagically */
-	med_pr_info("Registering event type %s(%s:%s->%s:%s)\n", ptr->name,
-		ptr->arg_name[0],ptr->arg_kclass[0]->name,
-		ptr->arg_name[1],ptr->arg_kclass[1]->name
-	);
+	med_evtype->name[MEDUSA_EVNAME_MAX-1] = '\0';
+	med_evtype->arg_name[0][MEDUSA_ATTRNAME_MAX-1] = '\0';
+	med_evtype->arg_name[1][MEDUSA_ATTRNAME_MAX-1] = '\0';
+	/* TODO: check whether kclasses are registered, maybe register automatically */
+	med_pr_info("Registering event type %s(%s:%s->%s:%s)\n", med_evtype->name,
+		med_evtype->arg_name[0],med_evtype->arg_kclass[0]->name,
+		med_evtype->arg_name[1],med_evtype->arg_kclass[1]->name);
 	MED_LOCK_W(registry_lock);
-	for (p=evtypes; p; p=p->next)
-		if (!mystrcmp(p->name, ptr->name)) {
+	for (p = evtypes; p; p = p->next)
+		if (strcmp(p->name, med_evtype->name) == 0) {
 			MED_UNLOCK_W(registry_lock);
-			med_pr_err("Error: such event type already exists.\n");
+			med_pr_err("Error: '%s' event type already exists.\n", med_evtype->name);
 			return -1;
 		}
-	ptr->next = evtypes;
-	ptr->bitnr = flags;
+
+	med_evtype->next = evtypes;
+	med_evtype->bitnr = flags;
 
 #define MASK (~(MEDUSA_EVTYPE_TRIGGEREDATOBJECT | MEDUSA_EVTYPE_TRIGGEREDATSUBJECT))
 	if (flags != MEDUSA_EVTYPE_NOTTRIGGERED)
-		for (p=evtypes; p; p ? (p=p->next) : (p=evtypes))
+		for (p = evtypes; p; p ? (p = p->next) : (p = evtypes))
 			if (p->bitnr != MEDUSA_EVTYPE_NOTTRIGGERED &&
-				(p->bitnr & MASK) == (ptr->bitnr & MASK)) {
+				(p->bitnr & MASK) == (med_evtype->bitnr & MASK)) {
 
-				ptr->bitnr++; /* TODO: check for the upper limit! */
+				med_evtype->bitnr++; /* TODO: check for the upper limit! */
 				p = NULL;
 				continue;
 			}
 #undef MASK
-	evtypes = ptr;
+
+	evtypes = med_evtype;
 	if (authserver && authserver->add_evtype)
-		authserver->add_evtype(ptr); /* TODO: some day, check for response */
+		authserver->add_evtype(med_evtype); /* TODO: some day, check for response */
 	MED_UNLOCK_W(registry_lock);
 	return 0;
 }
 
 /**
  * med_unregister_evtype - unregister an event type and notify the authserver.
- * @ptr: pointer to the event type to unregister
- *
+ * @med_evtype: pointer to the event type to unregister
+ * FIXME - this is not used anywhere
  */
-void med_unregister_evtype(struct medusa_evtype_s * ptr)
+void med_unregister_evtype(struct medusa_evtype_s *med_evtype)
 {
-	struct medusa_evtype_s * tmp;
-	med_pr_info("Unregistering event type %s\n", ptr->name);
+	struct medusa_evtype_s *tmp;
+	med_pr_info("Unregistering event type %s\n", med_evtype->name);
 	MED_LOCK_W(registry_lock);
-	if (ptr == evtypes)
-		evtypes = ptr->next;
-	else
-		for (tmp = evtypes; tmp; tmp = tmp->next)
-			if (tmp->next == ptr) {
-				tmp->next = tmp->next->next;
-				if (authserver && authserver->del_evtype)
-					authserver->del_evtype(ptr);
-				break;
-			}
+	if (med_evtype == evtypes)
+		evtypes = med_evtype->next;
+		MED_UNLOCK_W(registry_lock);
+		return;
+
+	for (tmp = evtypes; tmp; tmp = tmp->next) {
+		if (tmp->next == med_evtype) {
+			tmp->next = tmp->next->next;
+			if (authserver && authserver->del_evtype)
+				authserver->del_evtype(med_evtype);
+			break;
+		}
+	}
 	/* TODO: verify whether we found it */
 	MED_UNLOCK_W(registry_lock);
 }
 
 /**
  * med_register_authserver - register the authorization server
- * @ptr: pointer to the filled medusa_authserver_s structure
+ * @med_authserver: pointer to the filled medusa_authserver_s structure
  *
  * This routine inserts the authorization server in the internal data
  * structures, sets the use-count to 1 (i.e. returns get-servered entry),
  * and announces all known classes to the server.
  */
-int med_register_authserver(struct medusa_authserver_s * ptr)
+int med_register_authserver(struct medusa_authserver_s *med_authserver)
 {
-	struct medusa_kclass_s * cp;
-	struct medusa_evtype_s * ap;
+	struct medusa_kclass_s *cp;
+	struct medusa_evtype_s *ap;
 
-	med_pr_info("Registering authentication server %s\n", ptr->name);
+	med_pr_info("Registering authorization server %s\n", med_authserver->name);
 	MED_LOCK_W(registry_lock);
 	if (authserver) {
-		med_pr_err("Registration of auth. server '%s' failed: '%s' already present!\n", ptr->name, authserver->name);
+		med_pr_err("Failed registration of auth. server '%s', reason: '%s' already present!\n", med_authserver->name, authserver->name);
 		MED_UNLOCK_W(registry_lock);
 		return -1;
 	}
@@ -331,19 +296,19 @@ int med_register_authserver(struct medusa_authserver_s * ptr)
 	 * able to find the entry before it's in the linked list.
 	 * we set use-count to 1, and somebody has to decrement it some day.
 	 */
-	ptr->use_count = 1;
+	med_authserver->use_count = 1;
 	medusa_authserver_magic++;
-	authserver = ptr;
+	authserver = med_authserver;
 
 	/* we must remain in write-lock here, to synchronize add_*
 	 * events across our code.
 	 */
-	if (ptr->add_kclass)
+	if (med_authserver->add_kclass)
 		for (cp = kclasses; cp; cp = cp->next)
-			ptr->add_kclass(cp); /* TODO: some day we might want to check the return value, to support specialized servers */
-	if (ptr->add_evtype)
+			med_authserver->add_kclass(cp); /* TODO: some day we might want to check the return value, to support specialized servers */
+	if (med_authserver->add_evtype)
 		for (ap = evtypes; ap; ap = ap->next)
-			ptr->add_evtype(ap); /* TODO: the same for this */
+			med_authserver->add_evtype(ap); /* TODO: the same for this */
 
 	MED_UNLOCK_W(registry_lock);
 	return 0;
@@ -351,28 +316,28 @@ int med_register_authserver(struct medusa_authserver_s * ptr)
 
 /**
  * med_unregister_authserver - unlink the auth. server from L3.
- * @ptr: pointer to the server to unlink.
+ * @med_authserver: pointer to the server to unlink.
  *
  * This function is called by L4 code to unregister the auth. server.
  * After it has returned, no new questions will be placed to the server.
  * Note that some old questions might be pending, and after calling this,
  * it is wise to wait for close() callback to proceed with uninstallation.
  */
-void med_unregister_authserver(struct medusa_authserver_s * ptr)
+void med_unregister_authserver(struct medusa_authserver_s *med_authserver)
 {
-	med_pr_info("Unregistering authserver %s\n", ptr->name);
+	med_pr_info("Unregistering authserver %s\n", med_authserver->name);
 	MED_LOCK_W(registry_lock);
 	/* the following code is a little bit useless, but we keep it here
 	 * to allow multiple different authentication servers some day
 	 */
-	if (ptr != authserver) {
+	if (med_authserver != authserver) {
 		MED_UNLOCK_W(registry_lock);
 		return;
 	}
 	medusa_authserver_magic++;
 	authserver = NULL;
 	MED_UNLOCK_W(registry_lock);
-	med_put_authserver(ptr);
+	med_put_authserver(med_authserver);
 }
 
 /**
@@ -381,7 +346,7 @@ void med_unregister_authserver(struct medusa_authserver_s * ptr)
  * This function gets one more refference to the authserver. Use it,
  * when you want to be sure the authserver won't vanish.
  */
-struct medusa_authserver_s * med_get_authserver(void)
+struct medusa_authserver_s *med_get_authserver(void)
 {
 	MED_LOCK_W(usecount_lock);
 	if (authserver) {
@@ -395,23 +360,23 @@ struct medusa_authserver_s * med_get_authserver(void)
 
 /**
  * med_put_authserver - release the authserver by decrementing its use-count
- * @ptr: a pointer to the authserver
+ * @med_authserver: a pointer to the authserver
  *
  * This is an opposite function to med_get_authserver. Please, try to call
  * this without any locks; the close() callback of L4 server, which may
  * eventually get called from here, may block. This might change, if
  * reasonable.
  */
-void med_put_authserver(struct medusa_authserver_s * ptr)
+void med_put_authserver(struct medusa_authserver_s *med_authserver)
 {
 	MED_LOCK_W(usecount_lock);
-	if (ptr->use_count) /* sanity check only */
-		ptr->use_count--;
-	if (ptr->use_count) { /* fast path */
+	if (med_authserver->use_count) /* sanity check only */
+		med_authserver->use_count--;
+	if (med_authserver->use_count) { /* fast path */
 		MED_UNLOCK_W(usecount_lock);
 		return;
 	}
 	MED_UNLOCK_W(usecount_lock);
-	if (ptr->close)
-		ptr->close();
+	if (med_authserver->close)
+		med_authserver->close();
 }


### PR DESCRIPTION
The PR has as a goal to improve readability of registry.c a little. 

I gave a few variables a better more descriptive name.
med_unlink_kclass was refactored, the previous implementation could possibly try to access _next_ node of element, which is NULL and this was not safe.

med_get_kclass_by_name and med_get_kclass_by_cinfo were not used so they were removed.