### PR TITLE
Fix sleeping bug in auth server registration

### DIFF
--- a/security/medusa/l3/registry.c
+++ b/security/medusa/l3/registry.c
@@ -1,6 +1,7 @@
 #include <linux/medusa/l3/arch.h>
 #include <linux/medusa/l3/registry.h>
 #include "l3_internals.h"
+#include "../l4-constable/med_cache.h"
 
 /* nesting as follows: registry_lock is outer, usecount_lock is inner. */
 
@@ -172,6 +173,10 @@ int med_register_kclass(struct medusa_kclass_s *med_kclass)
 
 	med_kclass->name[MEDUSA_KCLASSNAME_MAX-1] = '\0';
 	med_pr_info("Registering kclass %s\n", med_kclass->name);
+
+	/* Register kmem cache for L4. */
+	med_cache_register(med_kclass->kobject_size);
+
 	MED_LOCK_W(registry_lock);
 	for (p = kclasses; p; p = p->next)
 		if (strcmp(p->name, med_kclass->name) == 0) {

--- a/security/medusa/l4-constable/Makefile
+++ b/security/medusa/l4-constable/Makefile
@@ -5,6 +5,6 @@
 
 export-objs :=  teleport_cycle teleport_reset
 
-l4-constable-y:= teleport.o chardev.o
+l4-constable-y:= teleport.o chardev.o med_cache.o
 obj-$(CONFIG_SECURITY_MEDUSA_L4_CONSTABLE) := l4-constable.o
 

--- a/security/medusa/l4-constable/chardev.c
+++ b/security/medusa/l4-constable/chardev.c
@@ -52,7 +52,6 @@
 
 #define MEDUSA_MAJOR 111
 #define MODULENAME "chardev/linux"
-#define CURRENTPTR current
 
 static int user_release(struct inode *inode, struct file *file);
 
@@ -910,7 +909,7 @@ static int user_open(struct inode *inode, struct file *file)
 		goto out;
 	}
 
-	constable = CURRENTPTR;
+	constable = current;
 	if (strstr(current->parent->comm, "gdb"))
 		gdb = current->parent;
 
@@ -943,7 +942,6 @@ static int user_open(struct inode *inode, struct file *file)
 out:
 	if (tele_mem_open)
 		med_cache_free(tele_mem_open);
-	med_cache_destroy();
 good_out:
 	up(&constable_openclose);
 	return retval;
@@ -1046,8 +1044,6 @@ static int user_release(struct inode *inode, struct file *file)
 	}
 	INIT_LIST_HEAD(&answer_waitlist);
 	up(&waitlist_sem);
-
-	free_med_cache_array();
 
 	up(&constable_openclose);
 	// wake up waiting processes, this has to be outside of constable_openclose

--- a/security/medusa/l4-constable/chardev.c
+++ b/security/medusa/l4-constable/chardev.c
@@ -41,7 +41,6 @@
 #include <linux/jiffies.h>
 #include <linux/sched/task.h>
 #include <linux/uaccess.h>
-#include <linux/slab.h>
 
 #include <linux/medusa/l3/arch.h>
 #include <linux/medusa/l3/registry.h>
@@ -49,12 +48,11 @@
 #include <linux/medusa/l4/comm.h>
 
 #include "teleport.h"
+#include "med_cache.h"
 
 #define MEDUSA_MAJOR 111
 #define MODULENAME "chardev/linux"
 #define CURRENTPTR current
-#define FAT_PTR_OFFSET_TYPE uint32_t
-#define FAT_PTR_OFFSET sizeof(FAT_PTR_OFFSET_TYPE)
 
 static int user_release(struct inode *inode, struct file *file);
 
@@ -111,10 +109,6 @@ struct tele_item {
 	void (*post)(void*);
 };
 
-// Array for memory caches
-int cache_array_size = 0;
-static struct kmem_cache **med_cache_array;
-
 // Next three variables are used by user_open. They are here because we have to
 // free the underlying data structures and clear them in user_close.
 static size_t left_in_teleport = 0;
@@ -162,143 +156,6 @@ static struct medusa_authserver_s chardev_medusa = {
 	NULL,			/* del_evtype */
 	l4_decide		/* decide */
 };
-
-/*******************************************************************************
- * memory cache interface
- */ 
-
-/**
- * Computes binary logarithm rounded up
- */
-static inline int get_log_index(int in) {
-	int ret = 1;
-	in--;
-	while (in >>= 1)
-		ret++;
-	return ret;
-}
-
-/**
- * Creates a memory cache on a given index.
- * If there is not enough space in the array, it will reallocate it.
- * If a cache already exists, it does nothing.
- */
-static struct kmem_cache* med_cache_create(size_t index) {
-	if (index >= cache_array_size)
-		return NULL;
-	if (med_cache_array[index])
-		return med_cache_array[index];
-	med_cache_array[index] = kmem_cache_create("med_cache",
-			1 << index,
-			0,
-			SLAB_HWCACHE_ALIGN,
-			NULL);
-	return med_cache_array[index];
-}
-
-/**
- * Allocates an array for memory caches and initializes it with nulls.
- */
-static struct kmem_cache** alloc_med_cache_array(size_t size) {
-	int i;
-	if (med_cache_array)
-		return med_cache_array;
-	med_cache_array = (struct kmem_cache**)
-		kmalloc(sizeof(struct kmem_cache*) * size, GFP_KERNEL);
-	if (med_cache_array) {
-		for (i = 0; i < size; i++)
-			med_cache_array[i] = NULL;
-		cache_array_size = size;
-	}
-	return med_cache_array;
-}
-
-/**
- * Reallocates the memory cache array for a given size.
- * If the size is smaller or the same as the existing array, it does nothing.
- */
-static struct kmem_cache** realloc_med_cache_array(size_t size) {
-	int i;
-	struct kmem_cache** new_cache_array;
-	if (size <= cache_array_size)
-		return med_cache_array;
-	new_cache_array = (struct kmem_cache**)
-		krealloc(med_cache_array, sizeof(struct kmem_cache*) * size, GFP_KERNEL);
-	if (new_cache_array) {
-		for (i = cache_array_size; i < size; i++)
-			med_cache_array[i] = NULL;
-		cache_array_size = size;
-	}
-	return new_cache_array;
-}
-
-/**
- * Creates a memory cache for a given size if it doesn't exist
- */
-static int med_cache_register(size_t size) {
-	int log;
-	size += FAT_PTR_OFFSET;
-	log = get_log_index(size);
-	if (log >= cache_array_size)
-		if (!realloc_med_cache_array(log))
-			return -ENOMEM;
-	if (!med_cache_array[log])
-		if (!med_cache_create(log))
-			return -ENOMEM;
-	return 0;
-}
-
-/**
- * Allocates memory from a memory pool chosen by the index argument
- * Warning - selected index has to take fat pointer offset into account
- */
-static void* med_cache_alloc_index(size_t index) {
-	void* ret;
-	ret = kmem_cache_alloc(med_cache_array[index], GFP_KERNEL);
-	*((FAT_PTR_OFFSET_TYPE*)ret) = index;
-	ret = ((FAT_PTR_OFFSET_TYPE*)ret) + 1;
-	return ret;
-}
-
-/**
- * Allocates memory from a memory pool chosen by the size argument
- */
-static void* med_cache_alloc_size(size_t size) {
-	int log;
-	size += FAT_PTR_OFFSET;
-	log = get_log_index(size);
-	return med_cache_alloc_index(log);
-}
-
-/**
- * Frees previously allocated memory
- */
-static void med_cache_free(void* mem) {
-	int log;
-	mem = ((FAT_PTR_OFFSET_TYPE*)mem) - 1;
-	log = *((FAT_PTR_OFFSET_TYPE*)mem);
-	kmem_cache_free(med_cache_array[log], mem);
-}
-
-/**
- * Destroys all memory caches in the array
- */
-static void med_cache_destroy(void) {
-	int i;
-	for(i = 0; i < cache_array_size; i++) {
-		if (med_cache_array[i])
-			kmem_cache_destroy(med_cache_array[i]);
-	}
-}
-
-/**
- * Frees the array of memory caches.
- */
-static void free_med_cache_array(void) {
-	med_cache_destroy();
-	kfree(med_cache_array);
-	med_cache_array = NULL;
-}
 
 /*
  * Used to clean up data structures after fetch or update.
@@ -348,8 +205,6 @@ static int l4_add_kclass(struct medusa_kclass_s * cl)
 	}
 
 	med_get_kclass(cl); // put is in user_release
-
-	med_cache_register(cl->kobject_size);
 
 	MED_LOCK_W(registration_lock);
 	barrier();
@@ -1024,10 +879,6 @@ static int user_open(struct inode *inode, struct file *file)
 	if (atomic_read(&constable_present))
 		goto good_out;
 
-	if (!alloc_med_cache_array(15)) {
-		retval = -ENOMEM;
-		goto out;
-	}
 	if (med_cache_register(sizeof(struct tele_item))) {
 		retval = -ENOMEM;
 		goto out;
@@ -1253,4 +1104,3 @@ static void chardev_constable_exit(void)
 module_init(chardev_constable_init);
 module_exit(chardev_constable_exit);
 MODULE_LICENSE("GPL");
-

--- a/security/medusa/l4-constable/med_cache.c
+++ b/security/medusa/l4-constable/med_cache.c
@@ -1,0 +1,157 @@
+/*
+ * Medusa L4 memory cache interface
+ *
+ * (C) 2018, 2020 Roderik Ploszek <roderik.ploszek@gmail.com>
+ */
+
+#include <linux/slab.h>
+
+#define FAT_PTR_OFFSET_TYPE uint32_t
+#define FAT_PTR_OFFSET sizeof(FAT_PTR_OFFSET_TYPE)
+
+// Array for memory caches
+int cache_array_size = 0;
+static struct kmem_cache **med_cache_array;
+
+/**
+ * Computes binary logarithm rounded up
+ */
+static inline int get_log_index(int in) {
+	int ret = 1;
+	in--;
+	while (in >>= 1)
+		ret++;
+	return ret;
+}
+
+/**
+ * Create a memory cache on a given index.
+ * If there is not enough space in the array, reallocate it.
+ * If a cache already exists, do nothing.
+ */
+static struct kmem_cache* med_cache_create(size_t index) {
+	if (index >= cache_array_size)
+		return NULL;
+	if (med_cache_array[index])
+		return med_cache_array[index];
+	med_cache_array[index] = kmem_cache_create("med_cache",
+			1 << index,
+			0,
+			SLAB_HWCACHE_ALIGN,
+			NULL);
+	return med_cache_array[index];
+}
+
+/**
+ * Allocate an array for memory caches and initialize it with nulls.
+ */
+struct kmem_cache** alloc_med_cache_array(size_t size) {
+	int i;
+	if (med_cache_array)
+		return med_cache_array;
+	med_cache_array = (struct kmem_cache**)
+		kmalloc(sizeof(struct kmem_cache*) * size, GFP_KERNEL);
+	if (med_cache_array) {
+		for (i = 0; i < size; i++)
+			med_cache_array[i] = NULL;
+		cache_array_size = size;
+	}
+	return med_cache_array;
+}
+
+/**
+ * Reallocate the memory cache array for a given size.
+ * If the size is smaller or the same as the existing array, do nothing.
+ */
+static struct kmem_cache** realloc_med_cache_array(size_t size) {
+	int i;
+	struct kmem_cache** new_cache_array;
+	if (size <= cache_array_size)
+		return med_cache_array;
+	new_cache_array = (struct kmem_cache**)
+		krealloc(med_cache_array, sizeof(struct kmem_cache*) * size, GFP_KERNEL);
+	if (new_cache_array) {
+		for (i = cache_array_size; i < size; i++)
+			med_cache_array[i] = NULL;
+		cache_array_size = size;
+	}
+	return new_cache_array;
+}
+
+/**
+ * Create a memory cache for a given size if it doesn't exist.
+ */
+int med_cache_register(size_t size) {
+	int log;
+	size += FAT_PTR_OFFSET;
+	log = get_log_index(size);
+	if (log >= cache_array_size)
+		if (!realloc_med_cache_array(log))
+			return -ENOMEM;
+	if (!med_cache_array[log])
+		if (!med_cache_create(log))
+			return -ENOMEM;
+	return 0;
+}
+
+/**
+ * Allocate memory from a memory pool chosen by the index argument.
+ * Warning - selected index has to take fat pointer offset into account!
+ */
+static void* med_cache_alloc_index(size_t index) {
+	void* ret;
+	ret = kmem_cache_alloc(med_cache_array[index], GFP_NOWAIT);
+	*((FAT_PTR_OFFSET_TYPE*)ret) = index;
+	ret = ((FAT_PTR_OFFSET_TYPE*)ret) + 1;
+	return ret;
+}
+
+/**
+ * Allocate memory from a memory pool chosen by the size argument.
+ */
+void* med_cache_alloc_size(size_t size) {
+	int log;
+	size += FAT_PTR_OFFSET;
+	log = get_log_index(size);
+	return med_cache_alloc_index(log);
+}
+
+/**
+ * Free previously allocated memory.
+ */
+void med_cache_free(void* mem) {
+	int log;
+	mem = ((FAT_PTR_OFFSET_TYPE*)mem) - 1;
+	log = *((FAT_PTR_OFFSET_TYPE*)mem);
+	kmem_cache_free(med_cache_array[log], mem);
+}
+
+/**
+ * Destroy all memory caches in the array.
+ */
+void med_cache_destroy(void) {
+	int i;
+	for(i = 0; i < cache_array_size; i++) {
+		if (med_cache_array[i])
+			kmem_cache_destroy(med_cache_array[i]);
+	}
+}
+
+/**
+ * Free the array of memory caches.
+ */
+void free_med_cache_array(void) {
+	med_cache_destroy();
+	kfree(med_cache_array);
+	med_cache_array = NULL;
+}
+
+/**
+ * Initialize the array of memory caches.
+ */
+static int __init init_med_cache(void) {
+	if (!alloc_med_cache_array(15))
+		return -ENOMEM;
+	return 0;
+}
+fs_initcall(init_med_cache);

--- a/security/medusa/l4-constable/med_cache.c
+++ b/security/medusa/l4-constable/med_cache.c
@@ -8,28 +8,42 @@
 
 #define FAT_PTR_OFFSET_TYPE uint32_t
 #define FAT_PTR_OFFSET sizeof(FAT_PTR_OFFSET_TYPE)
+/* Max size hint for the med_cache_array. Set it to the largest expected value,
+ * so it doesn't have to reallocate. Value 15 means that maximum cache size is
+ * 2^14 B before it has to be reallocated.
+ */
+#define CACHE_ARRAY_SIZE_HINT 15
 
-// Array for memory caches
-int cache_array_size = 0;
+/* Array for memory caches */
+int cache_array_size;
 static struct kmem_cache **med_cache_array;
 
 /**
- * Computes binary logarithm rounded up
+ * _log2_rounded_up() - Compute binary logarithm rounded up.
  */
-static inline int get_log_index(int in) {
+static inline int _log2_rounded_up(int in)
+{
 	int ret = 1;
+
 	in--;
 	while (in >>= 1)
 		ret++;
 	return ret;
 }
 
+static inline int get_mem_cache_index(size_t size)
+{
+	return _log2_rounded_up(FAT_PTR_OFFSET + size);
+}
+
 /**
- * Create a memory cache on a given index.
+ * med_cache_create() - Create a memory cache on a given index.
+ *
  * If there is not enough space in the array, reallocate it.
  * If a cache already exists, do nothing.
  */
-static struct kmem_cache* med_cache_create(size_t index) {
+static struct kmem_cache *med_cache_create(size_t index)
+{
 	if (index >= cache_array_size)
 		return NULL;
 	if (med_cache_array[index])
@@ -37,20 +51,23 @@ static struct kmem_cache* med_cache_create(size_t index) {
 	med_cache_array[index] = kmem_cache_create("med_cache",
 			1 << index,
 			0,
-			SLAB_HWCACHE_ALIGN,
+			SLAB_HWCACHE_ALIGN | SLAB_PANIC,
 			NULL);
 	return med_cache_array[index];
 }
 
 /**
- * Allocate an array for memory caches and initialize it with nulls.
+ * alloc_med_cache_array() - Allocate an array for memory caches and initialize
+ * it with nulls.
  */
-struct kmem_cache** alloc_med_cache_array(size_t size) {
+struct kmem_cache **alloc_med_cache_array(size_t size)
+{
 	int i;
+
 	if (med_cache_array)
 		return med_cache_array;
-	med_cache_array = (struct kmem_cache**)
-		kmalloc(sizeof(struct kmem_cache*) * size, GFP_KERNEL);
+	med_cache_array = (struct kmem_cache **)
+		kmalloc_array(size, sizeof(struct kmem_cache *), GFP_KERNEL);
 	if (med_cache_array) {
 		for (i = 0; i < size; i++)
 			med_cache_array[i] = NULL;
@@ -60,16 +77,20 @@ struct kmem_cache** alloc_med_cache_array(size_t size) {
 }
 
 /**
- * Reallocate the memory cache array for a given size.
+ * realloc_med_cache_array() - Reallocate the memory cache array for a given
+ * size.
+ *
  * If the size is smaller or the same as the existing array, do nothing.
  */
-static struct kmem_cache** realloc_med_cache_array(size_t size) {
+static struct kmem_cache **realloc_med_cache_array(size_t size)
+{
 	int i;
-	struct kmem_cache** new_cache_array;
+	struct kmem_cache **new_cache_array;
+
 	if (size <= cache_array_size)
 		return med_cache_array;
-	new_cache_array = (struct kmem_cache**)
-		krealloc(med_cache_array, sizeof(struct kmem_cache*) * size, GFP_KERNEL);
+	new_cache_array = (struct kmem_cache **)
+		krealloc(med_cache_array, sizeof(struct kmem_cache *) * size, GFP_KERNEL);
 	if (new_cache_array) {
 		for (i = cache_array_size; i < size; i++)
 			med_cache_array[i] = NULL;
@@ -79,78 +100,76 @@ static struct kmem_cache** realloc_med_cache_array(size_t size) {
 }
 
 /**
- * Create a memory cache for a given size if it doesn't exist.
+ * med_cache_register() - Create a memory cache for a given size if it doesn't
+ * exist.
+ *
+ * Note: Caches are registered from two places - user_open() in chardev.c and
+ * med_register_kclass() in registry.c. Unregistering is not supported as it's
+ * assumed the caches will be used until shutdown.
  */
-int med_cache_register(size_t size) {
-	int log;
-	size += FAT_PTR_OFFSET;
-	log = get_log_index(size);
-	if (log >= cache_array_size)
-		if (!realloc_med_cache_array(log))
+int med_cache_register(size_t size)
+{
+	int idx;
+
+	idx = get_mem_cache_index(size);
+	if (idx >= cache_array_size)
+		if (!realloc_med_cache_array(idx))
 			return -ENOMEM;
-	if (!med_cache_array[log])
-		if (!med_cache_create(log))
+	if (!med_cache_array[idx])
+		if (!med_cache_create(idx))
 			return -ENOMEM;
 	return 0;
 }
 
 /**
- * Allocate memory from a memory pool chosen by the index argument.
+ * med_cache_alloc_index() - Allocate memory from a memory pool chosen by the
+ * index argument.
+ * @index: Index of memory cache to use.
+ *
  * Warning - selected index has to take fat pointer offset into account!
+ *
+ * Return: Pointer to allocated memory.
  */
-static void* med_cache_alloc_index(size_t index) {
-	void* ret;
+static void *med_cache_alloc_index(size_t index)
+{
+	void *ret;
+
 	ret = kmem_cache_alloc(med_cache_array[index], GFP_NOWAIT);
-	*((FAT_PTR_OFFSET_TYPE*)ret) = index;
-	ret = ((FAT_PTR_OFFSET_TYPE*)ret) + 1;
+	*((FAT_PTR_OFFSET_TYPE *)ret) = index;
+	ret = ((FAT_PTR_OFFSET_TYPE *)ret) + 1;
 	return ret;
 }
 
 /**
- * Allocate memory from a memory pool chosen by the size argument.
+ * med_cache_alloc_size() - Allocate memory from a memory pool chosen by the
+ * size argument.
  */
-void* med_cache_alloc_size(size_t size) {
-	int log;
-	size += FAT_PTR_OFFSET;
-	log = get_log_index(size);
-	return med_cache_alloc_index(log);
+void *med_cache_alloc_size(size_t size)
+{
+	int idx;
+
+	idx = get_mem_cache_index(size);
+	return med_cache_alloc_index(idx);
 }
 
 /**
- * Free previously allocated memory.
+ * med_cache_free() - Free previously allocated memory.
  */
-void med_cache_free(void* mem) {
-	int log;
-	mem = ((FAT_PTR_OFFSET_TYPE*)mem) - 1;
-	log = *((FAT_PTR_OFFSET_TYPE*)mem);
-	kmem_cache_free(med_cache_array[log], mem);
+void med_cache_free(void *mem)
+{
+	int idx;
+
+	mem = ((FAT_PTR_OFFSET_TYPE *)mem) - 1;
+	idx = *((FAT_PTR_OFFSET_TYPE *)mem);
+	kmem_cache_free(med_cache_array[idx], mem);
 }
 
 /**
- * Destroy all memory caches in the array.
+ * init_med_cache() - Initialize the array of memory caches.
  */
-void med_cache_destroy(void) {
-	int i;
-	for(i = 0; i < cache_array_size; i++) {
-		if (med_cache_array[i])
-			kmem_cache_destroy(med_cache_array[i]);
-	}
-}
-
-/**
- * Free the array of memory caches.
- */
-void free_med_cache_array(void) {
-	med_cache_destroy();
-	kfree(med_cache_array);
-	med_cache_array = NULL;
-}
-
-/**
- * Initialize the array of memory caches.
- */
-static int __init init_med_cache(void) {
-	if (!alloc_med_cache_array(15))
+static int __init init_med_cache(void)
+{
+	if (!alloc_med_cache_array(CACHE_ARRAY_SIZE_HINT))
 		return -ENOMEM;
 	return 0;
 }

--- a/security/medusa/l4-constable/med_cache.h
+++ b/security/medusa/l4-constable/med_cache.h
@@ -1,0 +1,11 @@
+#ifndef _MEDUSA_CACHE_H
+#define _MEDUSA_CACHE_H
+
+struct kmem_cache** alloc_med_cache_array(size_t size);
+int med_cache_register(size_t size);
+void* med_cache_alloc_size(size_t size);
+void med_cache_free(void* mem);
+void med_cache_destroy(void);
+void free_med_cache_array(void);
+
+#endif

--- a/security/medusa/l4-constable/med_cache.h
+++ b/security/medusa/l4-constable/med_cache.h
@@ -1,11 +1,9 @@
 #ifndef _MEDUSA_CACHE_H
 #define _MEDUSA_CACHE_H
 
-struct kmem_cache** alloc_med_cache_array(size_t size);
+struct kmem_cache **alloc_med_cache_array(size_t size);
 int med_cache_register(size_t size);
-void* med_cache_alloc_size(size_t size);
-void med_cache_free(void* mem);
-void med_cache_destroy(void);
-void free_med_cache_array(void);
+void *med_cache_alloc_size(size_t size);
+void med_cache_free(void *mem);
 
 #endif


### PR DESCRIPTION
1) Call of med_cache_alloc_size() from l4_add_kclass() under
   registry_lock caused the bug. Fixed by changing GFP_KERNEL to
   GFP_NOWAIT in kmem_cache_alloc() call in kmem_cache_alloc_index().
2) Registration of memory cache in l4_add_kclass() caused another bug.
   This cannot be done under lock, so it was moved to L3. This caused a
   new problem:
3) As memory cache array was allocated in user_open(), it doesn't exist
   during registration of all kclasses and kevents in L3. The
   allocation was moved to fs_initcall, so it is done before
   initialization of L2 objects through device_initcall.