### PR TITLE
Fix memory leaks on ipc, task and inode security struct allocation.

### DIFF
--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -1777,7 +1777,6 @@ static int __init medusa_l1_init(void)
 
 	/* register the hooks */
 	security_add_hooks(medusa_l1_hooks, ARRAY_SIZE(medusa_l1_hooks), "medusa");
-	security_add_hooks(medusa_l1_hooks_special, ARRAY_SIZE(medusa_l1_hooks_special), "medusa");
 	//security_replace_hooks(medusa_l0_hooks, medusa_l1_hooks_special, ARRAY_SIZE(medusa_l1_hooks_special));
 
 	//l1_initialized = true;


### PR DESCRIPTION
Starting kernel v5.1 the LSM infrastructure does the allocation and
management of the security blobs automatically. By mistake commit
d57b9a8191 introduced registration of special hooks, which are
responsible for the allocation and management of the security blobs,
too. So there were made all allocation twice - one by the LSM
infrastructure itself, and second one by corresponding hook.

Special hooks (for allocation and management of security blobs) in
Medusa are not required at all. So this fix comment out the line
of code responsible for registration of those hooks.