### PR TITLE
Fix in all IPC acctypes trigger testing.

### DIFF
--- a/security/medusa/l2/acctype_ipc_associate.c
+++ b/security/medusa/l2/acctype_ipc_associate.c
@@ -70,7 +70,7 @@ medusa_answer_t medusa_ipc_associate(struct kern_ipc_perm *ipcp, int flag)
 		goto out;
 	}
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_associate_access, task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_O(ipc_associate_access, ipc_security(ipcp))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_ctl.c
+++ b/security/medusa/l2/acctype_ipc_ctl.c
@@ -89,7 +89,7 @@ medusa_answer_t medusa_ipc_ctl(struct kern_ipc_perm *ipcp, int cmd)
 	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_ctl_access, task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_O(ipc_ctl_access, ipc_security(ipcp))) {
 		memset(&access, '\0', sizeof(struct ipc_ctl_access));
 		access.cmd = cmd;
 		access.ipc_class = MED_IPC_UNDEFINED;

--- a/security/medusa/l2/acctype_ipc_msgrcv.c
+++ b/security/medusa/l2/acctype_ipc_msgrcv.c
@@ -75,7 +75,7 @@ medusa_answer_t medusa_ipc_msgrcv(struct kern_ipc_perm *ipcp, struct msg_msg *ms
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_msgrcv_access, task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_O(ipc_msgrcv_access, ipc_security(ipcp))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_msgsnd.c
+++ b/security/medusa/l2/acctype_ipc_msgsnd.c
@@ -67,7 +67,7 @@ medusa_answer_t medusa_ipc_msgsnd(struct kern_ipc_perm *ipcp, struct msg_msg *ms
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_msgsnd_access, task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_O(ipc_msgsnd_access, ipc_security(ipcp))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_permission.c
+++ b/security/medusa/l2/acctype_ipc_permission.c
@@ -127,7 +127,7 @@ medusa_answer_t medusa_ipc_permission(struct kern_ipc_perm *ipcp, u32 perms)
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_perm_access, task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_O(ipc_perm_access, ipc_security(ipcp))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_semop.c
+++ b/security/medusa/l2/acctype_ipc_semop.c
@@ -66,7 +66,7 @@ medusa_answer_t medusa_ipc_semop(struct kern_ipc_perm *ipcp, struct sembuf *sops
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_semop_access, task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_O(ipc_semop_access, ipc_security(ipcp))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)

--- a/security/medusa/l2/acctype_ipc_shmat.c
+++ b/security/medusa/l2/acctype_ipc_shmat.c
@@ -58,7 +58,7 @@ medusa_answer_t medusa_ipc_shmat(struct kern_ipc_perm *ipcp, char __user *shmadd
 	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (MEDUSA_MONITORED_ACCESS_S(ipc_shmat_access, task_security(current))) {
+	if (MEDUSA_MONITORED_ACCESS_O(ipc_shmat_access, ipc_security(ipcp))) {
 		process_kern2kobj(&process, current);
 		/* 3-th argument is true: decrement IPC object's refcount in returned object */
 		if (ipc_kern2kobj(&object, ipcp, true) == NULL)


### PR DESCRIPTION
All IPC acctypes are defined as TRIGGERED_AT_OBJECT, but in
acctype's executive code was used test related to SUBJECT
of an operation.

This fix changes related tests to test OBJECT of an operation.