### PR TITLE
Coding style ipc acctypes

### DIFF
--- a/security/medusa/l2/acctype_ipc_associate.c
+++ b/security/medusa/l2/acctype_ipc_associate.c
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * security/medusa/l2/acctype_ipc_associate.c
+ *
+ * IPC associate access type implementation.
+ *
+ * Copyright (C) 2017-2018 Viliam Mihalik
+ * Copyright (C) 2018-2020 Matus Jokay
+ */
+
 #include <linux/medusa/l3/registry.h>
 #include <linux/medusa/l1/task.h>
 #include <linux/medusa/l1/ipc.h>
@@ -8,20 +18,21 @@
 
 struct ipc_associate_access {
 	MEDUSA_ACCESS_HEADER;
-	int flag;	/* operation control flags */
+	int flag;		/* operation control flags */
 	unsigned int ipc_class;
 };
 
 MED_ATTRS(ipc_associate_access) {
-	MED_ATTR_RO (ipc_associate_access, flag, "flag", MED_SIGNED),
-	MED_ATTR_RO (ipc_associate_access, ipc_class, "ipc_class", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_associate_access, flag, "flag", MED_SIGNED),
+	MED_ATTR_RO(ipc_associate_access, ipc_class, "ipc_class", MED_UNSIGNED),
 	MED_ATTR_END
 };
 
 MED_ACCTYPE(ipc_associate_access, "ipc_associate", process_kobject, "process", ipc_kobject, "object");
 
-int __init ipc_acctype_associate_init(void) {
-	MED_REGISTER_ACCTYPE(ipc_associate_access,MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
+int __init ipc_acctype_associate_init(void)
+{
+	MED_REGISTER_ACCTYPE(ipc_associate_access, MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
 	return 0;
 }
 
@@ -58,13 +69,15 @@ medusa_answer_t medusa_ipc_associate(struct kern_ipc_perm *ipcp, int flag)
 		/* for now, we don't support error codes */
 		return MED_DENY;
 
-	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object))
+	    && process_kobj_validate_task(current) <= 0)
 		goto out;
-	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
+	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object))
+	    && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
-	if (!vs_intersects(VSS(task_security(current)),VS(ipc_security(ipcp))) ||
-		!vs_intersects(VSW(task_security(current)),VS(ipc_security(ipcp)))
+	if (!vs_intersects(VSS(task_security(current)), VS(ipc_security(ipcp)))
+	    || !vs_intersects(VSW(task_security(current)), VS(ipc_security(ipcp)))
 	) {
 		retval = MED_DENY;
 		goto out;
@@ -89,4 +102,5 @@ out:
 		retval = MED_DENY;
 	return retval;
 }
-__initcall(ipc_acctype_associate_init);
+
+device_initcall(ipc_acctype_associate_init);

--- a/security/medusa/l2/acctype_ipc_ctl.c
+++ b/security/medusa/l2/acctype_ipc_ctl.c
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * security/medusa/l2/acctype_ipc_ctl.c
+ *
+ * IPC ctl access type implementation.
+ *
+ * Copyright (C) 2017-2018 Viliam Mihalik
+ * Copyright (C) 2018-2020 Matus Jokay
+ */
+
 #include <linux/medusa/l3/registry.h>
 #include <linux/medusa/l1/task.h>
 #include <linux/medusa/l1/ipc.h>
@@ -8,20 +18,21 @@
 
 struct ipc_ctl_access {
 	MEDUSA_ACCESS_HEADER;
+	int cmd;		/* operation to be performed */
 	unsigned int ipc_class;
-	int cmd;	/* operation to be performed */
 };
 
 MED_ATTRS(ipc_ctl_access) {
-	MED_ATTR_RO (ipc_ctl_access, cmd, "cmd", MED_SIGNED),
-	MED_ATTR_RO (ipc_ctl_access, ipc_class, "ipc_class", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_ctl_access, cmd, "cmd", MED_SIGNED),
+	MED_ATTR_RO(ipc_ctl_access, ipc_class, "ipc_class", MED_UNSIGNED),
 	MED_ATTR_END
 };
 
 MED_ACCTYPE(ipc_ctl_access, "ipc_ctl", process_kobject, "process", ipc_kobject, "object");
 
-int __init ipc_acctype_ctl_init(void) {
-	MED_REGISTER_ACCTYPE(ipc_ctl_access,MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
+int __init ipc_acctype_ctl_init(void)
+{
+	MED_REGISTER_ACCTYPE(ipc_ctl_access, MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
 	return 0;
 }
 
@@ -82,11 +93,13 @@ medusa_answer_t medusa_ipc_ctl(struct kern_ipc_perm *ipcp, int cmd)
 			return MED_DENY;
 
 		object_p = &object;
-		if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
+		if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object))
+		    && ipc_kobj_validate_ipcp(ipcp) <= 0)
 			goto out;
 	}
 
-	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object))
+	    && process_kobj_validate_task(current) <= 0)
 		goto out;
 
 	if (MEDUSA_MONITORED_ACCESS_O(ipc_ctl_access, ipc_security(ipcp))) {
@@ -116,4 +129,5 @@ out:
 	}
 	return retval;
 }
-__initcall(ipc_acctype_ctl_init);
+
+device_initcall(ipc_acctype_ctl_init);

--- a/security/medusa/l2/acctype_ipc_msgrcv.c
+++ b/security/medusa/l2/acctype_ipc_msgrcv.c
@@ -20,7 +20,7 @@ struct ipc_msgrcv_access {
 	MEDUSA_ACCESS_HEADER;
 	long m_type;	/* message type; see 'struct msg_msg' in include/linux/msg.h */
 	size_t m_ts;	/* msg text size; see 'struct msg_msg' in include/linux/msg.h */
-	/* char m_text[???]; message text is not send, for now */
+	/* char m_text[???]; message text is not sent, for now */
 	pid_t target;	/* TODO: namespaces implementation */
 	long type;	/* type of requested message */
 	int mode;	/* operational flags */

--- a/security/medusa/l2/acctype_ipc_msgrcv.c
+++ b/security/medusa/l2/acctype_ipc_msgrcv.c
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * security/medusa/l2/acctype_ipc_msgrcv.c
+ *
+ * IPC msgrcv access type implementation.
+ *
+ * Copyright (C) 2017-2018 Viliam Mihalik
+ * Copyright (C) 2018-2020 Matus Jokay
+ */
+
 #include <linux/medusa/l3/registry.h>
 #include <linux/medusa/l1/task.h>
 #include <linux/medusa/l1/ipc.h>
@@ -8,29 +18,30 @@
 
 struct ipc_msgrcv_access {
 	MEDUSA_ACCESS_HEADER;
-	long m_type;	/* message type;  see 'struct msg_msg' in include/linux/msg.h */
+	long m_type;	/* message type; see 'struct msg_msg' in include/linux/msg.h */
 	size_t m_ts;	/* msg text size; see 'struct msg_msg' in include/linux/msg.h */
-	/* TODO char m_text[???]; send also message text? */
-	pid_t target; /* TODO: namespaces implementation??? */
+	/* char m_text[???]; message text is not send, for now */
+	pid_t target;	/* TODO: namespaces implementation */
 	long type;	/* type of requested message */
 	int mode;	/* operational flags */
 	unsigned int ipc_class;
 };
 
 MED_ATTRS(ipc_msgrcv_access) {
-	MED_ATTR_RO (ipc_msgrcv_access, m_type, "m_type", MED_SIGNED),
-	MED_ATTR_RO (ipc_msgrcv_access, m_ts, "m_ts", MED_UNSIGNED),
-	MED_ATTR_RO (ipc_msgrcv_access, target, "target", MED_SIGNED),
-	MED_ATTR_RO (ipc_msgrcv_access, type, "type", MED_SIGNED),
-	MED_ATTR_RO (ipc_msgrcv_access, mode, "mode", MED_SIGNED),
-	MED_ATTR_RO (ipc_msgrcv_access, ipc_class, "ipc_class", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_msgrcv_access, m_type, "m_type", MED_SIGNED),
+	MED_ATTR_RO(ipc_msgrcv_access, m_ts, "m_ts", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_msgrcv_access, target, "target", MED_SIGNED),
+	MED_ATTR_RO(ipc_msgrcv_access, type, "type", MED_SIGNED),
+	MED_ATTR_RO(ipc_msgrcv_access, mode, "mode", MED_SIGNED),
+	MED_ATTR_RO(ipc_msgrcv_access, ipc_class, "ipc_class", MED_UNSIGNED),
 	MED_ATTR_END
 };
 
 MED_ACCTYPE(ipc_msgrcv_access, "ipc_msgrcv", process_kobject, "process", ipc_kobject, "object");
 
-int __init ipc_acctype_msgrcv_init(void) {
-	MED_REGISTER_ACCTYPE(ipc_msgrcv_access,MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
+int __init ipc_acctype_msgrcv_init(void)
+{
+	MED_REGISTER_ACCTYPE(ipc_msgrcv_access, MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
 	return 0;
 }
 
@@ -58,7 +69,10 @@ int __init ipc_acctype_msgrcv_init(void) {
  *        |
  *        |<-- do_msgrcv() (always get ipcp->lock)
  */
-medusa_answer_t medusa_ipc_msgrcv(struct kern_ipc_perm *ipcp, struct msg_msg *msg, struct task_struct *target, long type, int mode)
+medusa_answer_t medusa_ipc_msgrcv(struct kern_ipc_perm *ipcp,
+				  struct msg_msg *msg,
+				  struct task_struct *target,
+				  long type, int mode)
 {
 	medusa_answer_t retval = MED_ALLOW;
 	struct ipc_msgrcv_access access;
@@ -70,9 +84,11 @@ medusa_answer_t medusa_ipc_msgrcv(struct kern_ipc_perm *ipcp, struct msg_msg *ms
 		/* for now, we don't support error codes */
 		return MED_DENY;
 
-	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object))
+	    && process_kobj_validate_task(current) <= 0)
 		goto out;
-	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
+	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object))
+	    && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
 	if (MEDUSA_MONITORED_ACCESS_O(ipc_msgrcv_access, ipc_security(ipcp))) {
@@ -98,4 +114,5 @@ out:
 		retval = MED_DENY;
 	return retval;
 }
-__initcall(ipc_acctype_msgrcv_init);
+
+device_initcall(ipc_acctype_msgrcv_init);

--- a/security/medusa/l2/acctype_ipc_msgsnd.c
+++ b/security/medusa/l2/acctype_ipc_msgsnd.c
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * security/medusa/l2/acctype_ipc_msgsnd.c
+ *
+ * IPC msgsnd access type implementation.
+ *
+ * Copyright (C) 2017-2018 Viliam Mihalik
+ * Copyright (C) 2018-2020 Matus Jokay
+ */
+
 #include <linux/medusa/l3/registry.h>
 #include <linux/medusa/l1/task.h>
 #include <linux/medusa/l1/ipc.h>
@@ -23,17 +33,18 @@ struct ipc_msgsnd_access {
 };
 
 MED_ATTRS(ipc_msgsnd_access) {
-	MED_ATTR_RO (ipc_msgsnd_access, m_type, "m_type", MED_SIGNED),
-	MED_ATTR_RO (ipc_msgsnd_access, m_ts, "m_ts", MED_UNSIGNED),
-	MED_ATTR_RO (ipc_msgsnd_access, msgflg, "msgflg", MED_SIGNED),
-	MED_ATTR_RO (ipc_msgsnd_access, ipc_class, "ipc_class", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_msgsnd_access, m_type, "m_type", MED_SIGNED),
+	MED_ATTR_RO(ipc_msgsnd_access, m_ts, "m_ts", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_msgsnd_access, msgflg, "msgflg", MED_SIGNED),
+	MED_ATTR_RO(ipc_msgsnd_access, ipc_class, "ipc_class", MED_UNSIGNED),
 	MED_ATTR_END
 };
 
 MED_ACCTYPE(ipc_msgsnd_access, "ipc_msgsnd", process_kobject, "process", ipc_kobject, "object");
 
-int __init ipc_acctype_msgsnd_init(void) {
-	MED_REGISTER_ACCTYPE(ipc_msgsnd_access,MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
+int __init ipc_acctype_msgsnd_init(void)
+{
+	MED_REGISTER_ACCTYPE(ipc_msgsnd_access, MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
 	return 0;
 }
 
@@ -50,7 +61,8 @@ int __init ipc_acctype_msgsnd_init(void) {
  *  |
  *  |<-- do_msgsnd() (always get ipcp->lock)
  */
-medusa_answer_t medusa_ipc_msgsnd(struct kern_ipc_perm *ipcp, struct msg_msg *msg, int msgflg)
+medusa_answer_t medusa_ipc_msgsnd(struct kern_ipc_perm *ipcp,
+				  struct msg_msg *msg, int msgflg)
 {
 	medusa_answer_t retval = MED_ALLOW;
 	struct ipc_msgsnd_access access;
@@ -62,9 +74,11 @@ medusa_answer_t medusa_ipc_msgsnd(struct kern_ipc_perm *ipcp, struct msg_msg *ms
 		/* for now, we don't support error codes */
 		return MED_DENY;
 
-	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object))
+	    && process_kobj_validate_task(current) <= 0)
 		goto out;
-	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
+	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object))
+	    && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
 	if (MEDUSA_MONITORED_ACCESS_O(ipc_msgsnd_access, ipc_security(ipcp))) {
@@ -88,4 +102,5 @@ out:
 		retval = MED_DENY;
 	return retval;
 }
-__initcall(ipc_acctype_msgsnd_init);
+
+device_initcall(ipc_acctype_msgsnd_init);

--- a/security/medusa/l2/acctype_ipc_permission.c
+++ b/security/medusa/l2/acctype_ipc_permission.c
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * security/medusa/l2/acctype_ipc_permission.c
+ *
+ * IPC permission access type implementation.
+ *
+ * Copyright (C) 2017-2018 Viliam Mihalik
+ * Copyright (C) 2018-2020 Matus Jokay
+ */
+
 #include <linux/medusa/l3/registry.h>
 #include <linux/medusa/l1/task.h>
 #include <linux/medusa/l1/ipc.h>
@@ -9,19 +19,20 @@
 struct ipc_perm_access {
 	MEDUSA_ACCESS_HEADER;
 	unsigned int ipc_class;
-	u32 perms;	/* desired (requested) permission set */
+	u32 perms;		/* desired (requested) permission set */
 };
 
 MED_ATTRS(ipc_perm_access) {
-	MED_ATTR_RO (ipc_perm_access, perms, "perms", MED_UNSIGNED),
-	MED_ATTR_RO (ipc_perm_access, ipc_class, "ipc_class", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_perm_access, perms, "perms", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_perm_access, ipc_class, "ipc_class", MED_UNSIGNED),
 	MED_ATTR_END
 };
 
 MED_ACCTYPE(ipc_perm_access, "ipc_perm", process_kobject, "process", ipc_kobject, "object");
 
-int __init ipc_acctype_init(void) {
-	MED_REGISTER_ACCTYPE(ipc_perm_access,MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
+int __init ipc_acctype_perm_init(void)
+{
+	MED_REGISTER_ACCTYPE(ipc_perm_access, MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
 	return 0;
 }
 
@@ -122,9 +133,11 @@ medusa_answer_t medusa_ipc_permission(struct kern_ipc_perm *ipcp, u32 perms)
 		/* for now, we don't support error codes */
 		return MED_DENY;
 
-	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object))
+	    && process_kobj_validate_task(current) <= 0)
 		goto out;
-	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
+	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object))
+	    && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
 	if (MEDUSA_MONITORED_ACCESS_O(ipc_perm_access, ipc_security(ipcp))) {
@@ -150,4 +163,5 @@ out:
 		retval = MED_DENY;
 	return retval;
 }
-__initcall(ipc_acctype_init);
+
+device_initcall(ipc_acctype_perm_init);

--- a/security/medusa/l2/acctype_ipc_semop.c
+++ b/security/medusa/l2/acctype_ipc_semop.c
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * security/medusa/l2/acctype_ipc_semop.c
+ *
+ * IPC semop access type implementation.
+ *
+ * Copyright (C) 2017-2018 Viliam Mihalik
+ * Copyright (C) 2018-2020 Matus Jokay
+ */
+
 #include <linux/medusa/l3/registry.h>
 #include <linux/medusa/l1/task.h>
 #include <linux/medusa/l1/ipc.h>
@@ -9,7 +19,8 @@
 struct ipc_semop_access {
 	MEDUSA_ACCESS_HEADER;
 	/* sem_num, sem_op and sem_flg are from sembuf struct definition;
-	   see include/uapi/linux/sem.h */
+	 * see include/uapi/linux/sem.h
+	 */
 	unsigned int sem_num;	/* semaphore index in array */
 	int sem_op;		/* semaphore operation */
 	int sem_flg;		/* operation flags */
@@ -19,19 +30,20 @@ struct ipc_semop_access {
 };
 
 MED_ATTRS(ipc_semop_access) {
-	MED_ATTR_RO (ipc_semop_access, sem_num, "sem_num", MED_UNSIGNED),
-	MED_ATTR_RO (ipc_semop_access, sem_op, "sem_op", MED_SIGNED),
-	MED_ATTR_RO (ipc_semop_access, sem_flg, "sem_flg", MED_SIGNED),
-	MED_ATTR_RO (ipc_semop_access, nsops, "nsops", MED_UNSIGNED),
-	MED_ATTR_RO (ipc_semop_access, alter, "alter", MED_SIGNED),
-	MED_ATTR_RO (ipc_semop_access, ipc_class, "ipc_class", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_semop_access, sem_num, "sem_num", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_semop_access, sem_op, "sem_op", MED_SIGNED),
+	MED_ATTR_RO(ipc_semop_access, sem_flg, "sem_flg", MED_SIGNED),
+	MED_ATTR_RO(ipc_semop_access, nsops, "nsops", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_semop_access, alter, "alter", MED_SIGNED),
+	MED_ATTR_RO(ipc_semop_access, ipc_class, "ipc_class", MED_UNSIGNED),
 	MED_ATTR_END
 };
 
 MED_ACCTYPE(ipc_semop_access, "ipc_semop", process_kobject, "process", ipc_kobject, "object");
 
-int __init ipc_acctype_semop_init(void) {
-	MED_REGISTER_ACCTYPE(ipc_semop_access,MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
+int __init ipc_acctype_semop_init(void)
+{
+	MED_REGISTER_ACCTYPE(ipc_semop_access, MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
 	return 0;
 }
 
@@ -49,7 +61,9 @@ int __init ipc_acctype_semop_init(void) {
  *  |
  *  |<-- do_semtimedop()
  */
-medusa_answer_t medusa_ipc_semop(struct kern_ipc_perm *ipcp, struct sembuf *sops, unsigned nsops, int alter)
+medusa_answer_t medusa_ipc_semop(struct kern_ipc_perm *ipcp,
+				 struct sembuf *sops, unsigned int nsops,
+				 int alter)
 {
 	medusa_answer_t retval = MED_ALLOW;
 	struct ipc_semop_access access;
@@ -61,9 +75,11 @@ medusa_answer_t medusa_ipc_semop(struct kern_ipc_perm *ipcp, struct sembuf *sops
 		/* for now, we don't support error codes */
 		return MED_DENY;
 
-	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object))
+	    && process_kobj_validate_task(current) <= 0)
 		goto out;
-	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
+	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object))
+	    && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
 	if (MEDUSA_MONITORED_ACCESS_O(ipc_semop_access, ipc_security(ipcp))) {
@@ -89,4 +105,5 @@ out:
 		retval = MED_DENY;
 	return retval;
 }
-__initcall(ipc_acctype_semop_init);
+
+device_initcall(ipc_acctype_semop_init);

--- a/security/medusa/l2/acctype_ipc_shmat.c
+++ b/security/medusa/l2/acctype_ipc_shmat.c
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * security/medusa/l2/acctype_ipc_shmat.c
+ *
+ * IPC shmat access type implementation.
+ *
+ * Copyright (C) 2017-2018 Viliam Mihalik
+ * Copyright (C) 2018-2020 Matus Jokay
+ */
+
 #include <linux/medusa/l3/registry.h>
 #include <linux/medusa/l1/task.h>
 #include <linux/medusa/l1/ipc.h>
@@ -14,16 +24,17 @@ struct ipc_shmat_access {
 };
 
 MED_ATTRS(ipc_shmat_access) {
-	MED_ATTR_RO (ipc_shmat_access, shmflg, "shmflg", MED_SIGNED),
-	MED_ATTR_RO (ipc_shmat_access, shmaddr, "shmaddr", MED_UNSIGNED),
-	MED_ATTR_RO (ipc_shmat_access, ipc_class, "ipc_class", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_shmat_access, shmflg, "shmflg", MED_SIGNED),
+	MED_ATTR_RO(ipc_shmat_access, shmaddr, "shmaddr", MED_UNSIGNED),
+	MED_ATTR_RO(ipc_shmat_access, ipc_class, "ipc_class", MED_UNSIGNED),
 	MED_ATTR_END
 };
 
 MED_ACCTYPE(ipc_shmat_access, "ipc_shmat", process_kobject, "process", ipc_kobject, "object");
 
-int __init ipc_acctype_shmat_init(void) {
-	MED_REGISTER_ACCTYPE(ipc_shmat_access,MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
+int __init ipc_acctype_shmat_init(void)
+{
+	MED_REGISTER_ACCTYPE(ipc_shmat_access, MEDUSA_ACCTYPE_TRIGGEREDATOBJECT);
 	return 0;
 }
 
@@ -41,7 +52,8 @@ int __init ipc_acctype_shmat_init(void) {
  *  |
  *  |<-- do_shmat()
  */
-medusa_answer_t medusa_ipc_shmat(struct kern_ipc_perm *ipcp, char __user *shmaddr, int shmflg)
+medusa_answer_t medusa_ipc_shmat(struct kern_ipc_perm *ipcp,
+				 char __user *shmaddr, int shmflg)
 {
 	medusa_answer_t retval = MED_ALLOW;
 	struct ipc_shmat_access access;
@@ -53,9 +65,11 @@ medusa_answer_t medusa_ipc_shmat(struct kern_ipc_perm *ipcp, char __user *shmadd
 		/* for now, we don't support error codes */
 		return MED_DENY;
 
-	if (!is_med_magic_valid(&(task_security(current)->med_object)) && process_kobj_validate_task(current) <= 0)
+	if (!is_med_magic_valid(&(task_security(current)->med_object))
+	    && process_kobj_validate_task(current) <= 0)
 		goto out;
-	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object)) && ipc_kobj_validate_ipcp(ipcp) <= 0)
+	if (!is_med_magic_valid(&(ipc_security(ipcp)->med_object))
+	    && ipc_kobj_validate_ipcp(ipcp) <= 0)
 		goto out;
 
 	if (MEDUSA_MONITORED_ACCESS_O(ipc_shmat_access, ipc_security(ipcp))) {
@@ -78,4 +92,5 @@ out:
 		retval = MED_DENY;
 	return retval;
 }
-__initcall(ipc_acctype_shmat_init);
+
+device_initcall(ipc_acctype_shmat_init);


### PR DESCRIPTION
Improve coding style of l2/acctype_ipc_*.c files:

1) fix indentation
2) add license and author header
3) instead of __initcall() use device_initcall()
4) remove preprocessor conditionals (see Linux coding style - Conditional Compilation)

Used scripts/Lindent and scripts/checkpatch.pl