### PR TITLE
A few path hooks

### DIFF
--- a/security/medusa/include/l1/inode.h
+++ b/security/medusa/include/l1/inode.h
@@ -41,7 +41,7 @@ extern enum medusa_answer_t medusa_readlink(struct dentry *dentry);
  */
 
 extern int file_kobj_validate_dentry(struct dentry *dentry, struct vfsmount *mnt, struct path *dir);
-extern int file_kobj_validate_dentry_dir(const struct path *dir, struct dentry *dentry);
+extern int file_kobj_validate_dentry_dir(const struct vfsmount *mnt, struct dentry *dentry);
 extern void medusa_get_upper_and_parent(struct path *ndsource, struct path *ndupperp, struct path *ndparentp);
 extern void medusa_put_upper_and_parent(struct path *ndupper, struct path *ndparent);
 extern struct vfsmount *medusa_evocate_mnt(struct dentry *dentry);

--- a/security/medusa/include/l1/inode.h
+++ b/security/medusa/include/l1/inode.h
@@ -25,8 +25,8 @@ extern enum medusa_answer_t medusa_create(struct dentry *dentry, int mode);
 extern enum medusa_answer_t medusa_lookup(struct inode *dir, struct dentry **dentry);
 extern enum medusa_answer_t medusa_truncate(struct dentry *dentry, unsigned long length);
 extern enum medusa_answer_t medusa_mkdir(const struct path *dir, struct dentry *dentry, int mode);
-extern medusa_answer_t medusa_mknod(const struct path *dir,
-				struct dentry *dentry, umode_t mode, unsigned int dev);
+extern enum medusa_answer_t medusa_mknod(const struct path *dir,
+					struct dentry *dentry, umode_t mode, unsigned int dev);
 extern enum medusa_answer_t medusa_permission(struct inode *inode, int mask);
 extern enum medusa_answer_t medusa_rmdir(const struct path *dir, struct dentry *dentry);
 extern enum medusa_answer_t medusa_symlink(struct dentry *dentry, const char *oldname);

--- a/security/medusa/include/l1/inode.h
+++ b/security/medusa/include/l1/inode.h
@@ -24,12 +24,13 @@ extern enum medusa_answer_t medusa_exec(struct dentry **dentryp);
 extern enum medusa_answer_t medusa_create(struct dentry *dentry, int mode);
 extern enum medusa_answer_t medusa_lookup(struct inode *dir, struct dentry **dentry);
 extern enum medusa_answer_t medusa_truncate(struct dentry *dentry, unsigned long length);
-extern enum medusa_answer_t medusa_mkdir(const struct path *parent, struct dentry *dentry, int mode);
-extern enum medusa_answer_t medusa_mknod(struct dentry *dentry, dev_t dev, int mode);
+extern enum medusa_answer_t medusa_mkdir(const struct path *dir, struct dentry *dentry, int mode);
+extern medusa_answer_t medusa_mknod(const struct path *dir,
+				struct dentry *dentry, umode_t mode, unsigned int dev);
 extern enum medusa_answer_t medusa_permission(struct inode *inode, int mask);
 extern enum medusa_answer_t medusa_rmdir(const struct path *dir, struct dentry *dentry);
 extern enum medusa_answer_t medusa_symlink(struct dentry *dentry, const char *oldname);
-extern enum medusa_answer_t medusa_unlink(struct dentry *dentry);
+extern enum medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry);
 extern enum medusa_answer_t medusa_link(struct dentry *dentry, const char *newname);
 extern enum medusa_answer_t medusa_rename(struct dentry *dentry, const char *newname);
 extern enum medusa_answer_t medusa_readlink(struct dentry *dentry);
@@ -39,8 +40,8 @@ extern enum medusa_answer_t medusa_readlink(struct dentry *dentry);
  * l2/evtype_getfile.c. Look there before using any of these routines.
  */
 
-extern int file_kobj_validate_dentry(struct dentry *dentry, struct vfsmount *mnt);
-extern int file_kobj_validate_dentry_dir(struct dentry *dentry, const struct path *dir);
+extern int file_kobj_validate_dentry(struct dentry *dentry, struct vfsmount *mnt, struct path *dir);
+extern int file_kobj_validate_dentry_dir(const struct path *dir, struct dentry *dentry);
 extern void medusa_get_upper_and_parent(struct path *ndsource, struct path *ndupperp, struct path *ndparentp);
 extern void medusa_put_upper_and_parent(struct path *ndupper, struct path *ndparent);
 extern struct vfsmount *medusa_evocate_mnt(struct dentry *dentry);

--- a/security/medusa/include/l1/inode.h
+++ b/security/medusa/include/l1/inode.h
@@ -40,6 +40,7 @@ extern enum medusa_answer_t medusa_readlink(struct dentry *dentry);
  */
 
 extern int file_kobj_validate_dentry(struct dentry *dentry, struct vfsmount *mnt);
+extern int file_kobj_validate_dentry_dir(struct dentry *dentry, const struct path *dir);
 extern void medusa_get_upper_and_parent(struct path *ndsource, struct path *ndupperp, struct path *ndparentp);
 extern void medusa_put_upper_and_parent(struct path *ndupper, struct path *ndparent);
 extern struct vfsmount *medusa_evocate_mnt(struct dentry *dentry);

--- a/security/medusa/include/l2/kobject_file.h
+++ b/security/medusa/include/l2/kobject_file.h
@@ -59,6 +59,7 @@ void file_kobj_live_remove(struct inode *ino);
 
 /* conversion beteween filename (stored in dentry) and static buffer */
 void file_kobj_dentry2string(struct dentry *dentry, char *buf);
+void file_kobj_dentry2string_mnt(struct path *dir, struct dentry *dentry, char *buf);
 void file_kobj_dentry2string_dir(struct path *dir, struct dentry *dentry, char *buf);
 
 #endif

--- a/security/medusa/include/l2/kobject_file.h
+++ b/security/medusa/include/l2/kobject_file.h
@@ -59,5 +59,6 @@ void file_kobj_live_remove(struct inode *ino);
 
 /* conversion beteween filename (stored in dentry) and static buffer */
 void file_kobj_dentry2string(struct dentry *dentry, char *buf);
+void file_kobj_dentry2string_dir(struct path *dir, struct dentry *dentry, char *buf);
 
 #endif

--- a/security/medusa/include/l2/kobject_file.h
+++ b/security/medusa/include/l2/kobject_file.h
@@ -59,7 +59,7 @@ void file_kobj_live_remove(struct inode *ino);
 
 /* conversion beteween filename (stored in dentry) and static buffer */
 void file_kobj_dentry2string(struct dentry *dentry, char *buf);
-void file_kobj_dentry2string_mnt(struct path *dir, struct dentry *dentry, char *buf);
+void file_kobj_dentry2string_mnt(const struct path *dir, struct dentry *dentry, char *buf);
 void file_kobj_dentry2string_dir(struct path *dir, struct dentry *dentry, char *buf);
 
 #endif

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -292,7 +292,7 @@ static int medusa_l1_inode_permission(struct inode *inode, int mask)
 	if (no_block)
 		return -ECHILD;
 
-	mask &= (MAY_READ|MAY_WRITE|MAY_EXEC|MAY_APPEND);
+	mask &= (MAY_READ|MAY_WRITE|MAY_EXEC|MAY_APPEND);*/
 	/*
 	 * Existence test.
 	 * TODO What about Medusa SEE permission?
@@ -381,6 +381,10 @@ static int medusa_l1_path_mkdir(const struct path *dir, struct dentry *dentry,
 
 static int medusa_l1_path_rmdir(const struct path *dir, struct dentry *dentry)
 {
+	struct mount *mnt = real_mount(dir->mnt);
+	pr_info("rmdir dir dentry: %pd\n", dir->dentry);
+	pr_info("rmdir dentry: %pd\n", dentry);
+	pr_cont("mountpoint: %pd, vfs mnt root: %pd\n", mnt->mnt_mountpoint, mnt->mnt.mnt_root);
 	if (medusa_rmdir(dir, dentry) == MED_DENY)
 		return -EACCES;
 	return 0;

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -380,8 +380,8 @@ static int medusa_l1_path_mkdir(const struct path *dir, struct dentry *dentry,
 	char *pos = d_absolute_path(dir, buf, 127);
 	if (!IS_ERR(pos))
 		med_pr_info("mkdir: %s", pos);
-	if (medusa_mkdir(dir, dentry, mode) == MED_NO)
-		return -EPERM;
+	if (medusa_mkdir(dir, dentry, mode) == MED_DENY)
+		return -EACCES;
 	return 0;
 }
 
@@ -402,7 +402,7 @@ static int medusa_l1_path_unlink(const struct path *dir, struct dentry *dentry)
 	char *pos = d_absolute_path(dir, buf, 127);
 	if (!IS_ERR(pos))
 		med_pr_info("unlink: %s", pos);
-	if (medusa_unlink(dir, dentry) == MED_NO)
+	if (medusa_unlink(dir, dentry) == MED_DENY)
 		return -EPERM;
 	return 0;
 }

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -392,6 +392,8 @@ static int medusa_l1_path_rmdir(const struct path *dir, struct dentry *dentry)
 
 static int medusa_l1_path_unlink(const struct path *dir, struct dentry *dentry)
 {
+	if (medusa_unlink(dir, dentry) == MED_NO)
+		return -EPERM;
 	return 0;
 }
 
@@ -1469,7 +1471,7 @@ static struct security_hook_list medusa_l1_hooks[] = {
 	//LSM_HOOK_INIT(dentry_init_security, medusa_l1_dentry_init_security),
 
 #ifdef CONFIG_SECURITY_PATH
-	//LSM_HOOK_INIT(path_unlink, medusa_l1_path_unlink),
+	LSM_HOOK_INIT(path_unlink, medusa_l1_path_unlink),
 	//LSM_HOOK_INIT(path_mkdir, medusa_l1_path_mkdir),
 	LSM_HOOK_INIT(path_rmdir, medusa_l1_path_rmdir),
 	//LSM_HOOK_INIT(path_mknod, medusa_l1_path_mknod),
@@ -1485,7 +1487,6 @@ static struct security_hook_list medusa_l1_hooks[] = {
 	//LSM_HOOK_INIT(inode_init_security, medusa_l1_inode_init_security),
 	LSM_HOOK_INIT(inode_create, medusa_l1_inode_create),
 	LSM_HOOK_INIT(inode_link, medusa_l1_inode_link),
-	//LSM_HOOK_INIT(inode_unlink, medusa_l1_inode_unlink),
 	LSM_HOOK_INIT(inode_symlink, medusa_l1_inode_symlink),
 	//LSM_HOOK_INIT(inode_mkdir, medusa_l1_inode_mkdir),
 	// LSM_HOOK_INIT(inode_rmdir, medusa_l1_inode_rmdir),

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -1483,7 +1483,7 @@ static struct security_hook_list medusa_l1_hooks[] = {
 #ifdef CONFIG_SECURITY_PATH
 	LSM_HOOK_INIT(path_unlink, medusa_l1_path_unlink),
 	LSM_HOOK_INIT(path_mkdir, medusa_l1_path_mkdir),
-	// LSM_HOOK_INIT(path_rmdir, medusa_l1_path_rmdir),
+	LSM_HOOK_INIT(path_rmdir, medusa_l1_path_rmdir),
 	//LSM_HOOK_INIT(path_mknod, medusa_l1_path_mknod),
 	//LSM_HOOK_INIT(path_truncate, medusa_l1_path_truncate),
 	//LSM_HOOK_INIT(path_symlink, medusa_l1_path_symlink),

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -256,8 +256,8 @@ static int medusa_l1_inode_rmdir(struct inode *inode, struct dentry *dentry)
 static int medusa_l1_inode_mknod(struct inode *inode, struct dentry *dentry,
 				 umode_t mode, dev_t dev)
 {
-	if (medusa_mknod(dentry, dev, mode) == MED_DENY)
-		return -EACCES;
+	/* if (medusa_mknod(dentry, dev, mode) == MED_DENY) */
+		/* return -EACCES; */
 	return 0;
 }
 
@@ -370,6 +370,8 @@ static int medusa_l1_inode_permission(struct inode *inode, int mask)
 static int medusa_l1_path_mknod(const struct path *dir, struct dentry *dentry,
 				umode_t mode, unsigned int dev)
 {
+	if(medusa_mknod(dir, dentry, mode, dev) == MED_DENY)
+		return -EACCES;
 	return 0;
 }
 
@@ -1484,7 +1486,7 @@ static struct security_hook_list medusa_l1_hooks[] = {
 	LSM_HOOK_INIT(path_unlink, medusa_l1_path_unlink),
 	LSM_HOOK_INIT(path_mkdir, medusa_l1_path_mkdir),
 	LSM_HOOK_INIT(path_rmdir, medusa_l1_path_rmdir),
-	//LSM_HOOK_INIT(path_mknod, medusa_l1_path_mknod),
+	LSM_HOOK_INIT(path_mknod, medusa_l1_path_mknod),
 	//LSM_HOOK_INIT(path_truncate, medusa_l1_path_truncate),
 	//LSM_HOOK_INIT(path_symlink, medusa_l1_path_symlink),
 	// mY LSM_HOOK_INIT(path_link, medusa_l1_path_link),

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -391,9 +391,9 @@ static int medusa_l1_path_mkdir(const struct path *dir, struct dentry *dentry,
 static int medusa_l1_path_rmdir(const struct path *dir, struct dentry *dentry)
 {
 	struct mount *mnt = real_mount(dir->mnt);
-	pr_info("rmdir dir dentry: %pd\n", dir->dentry);
-	pr_info("rmdir dentry: %pd\n", dentry);
-	pr_cont("mountpoint: %pd, vfs mnt root: %pd\n", mnt->mnt_mountpoint, mnt->mnt.mnt_root);
+	med_pr_info("rmdir dir dentry: %pd\n", dir->dentry);
+	med_pr_info("rmdir dentry: %pd\n", dentry);
+	med_pr_info("mountpoint: %pd, vfs mnt root: %pd\n", mnt->mnt_mountpoint, mnt->mnt.mnt_root);
 	if (medusa_rmdir(dir, dentry) == MED_DENY)
 		return -EACCES;
 	return 0;
@@ -1498,16 +1498,16 @@ static struct security_hook_list medusa_l1_hooks[] = {
 
 #endif /* CONFIG_SECURITY_PATH */
 	//LSM_HOOK_INIT(inode_init_security, medusa_l1_inode_init_security),
-	// LSM_HOOK_INIT(inode_create, medusa_l1_inode_create),
+	LSM_HOOK_INIT(inode_create, medusa_l1_inode_create),
 	// LSM_HOOK_INIT(inode_mkdir, medusa_l1_inode_mkdir),
-	// LSM_HOOK_INIT(inode_link, medusa_l1_inode_link),
-	// LSM_HOOK_INIT(inode_symlink, medusa_l1_inode_symlink),
+	LSM_HOOK_INIT(inode_link, medusa_l1_inode_link),
+	LSM_HOOK_INIT(inode_symlink, medusa_l1_inode_symlink),
 	// LSM_HOOK_INIT(inode_rmdir, medusa_l1_inode_rmdir),
 	// LSM_HOOK_INIT(inode_mknod, medusa_l1_inode_mknod),
 	//LSM_HOOK_INIT(inode_rename, medusa_l1_inode_rename),
-	// LSM_HOOK_INIT(inode_readlink, medusa_l1_inode_readlink),
+	LSM_HOOK_INIT(inode_readlink, medusa_l1_inode_readlink),
 	//LSM_HOOK_INIT(inode_follow_link, medusa_l1_inode_follow_link),
-	// LSM_HOOK_INIT(inode_permission, medusa_l1_inode_permission),
+	LSM_HOOK_INIT(inode_permission, medusa_l1_inode_permission),
 	//LSM_HOOK_INIT(inode_setattr, medusa_l1_inode_setattr),
 	//LSM_HOOK_INIT(inode_getattr, medusa_l1_inode_getattr),
 	//LSM_HOOK_INIT(inode_setxattr, medusa_l1_inode_setxattr),
@@ -1534,7 +1534,7 @@ static struct security_hook_list medusa_l1_hooks[] = {
 	//LSM_HOOK_INIT(file_set_fowner, medusa_l1_file_set_fowner),
 	//LSM_HOOK_INIT(file_send_sigiotask, medusa_l1_file_send_sigiotask),
 	//LSM_HOOK_INIT(file_receive, medusa_l1_file_receive),
-	// LSM_HOOK_INIT(file_open, medusa_l1_file_open),
+	LSM_HOOK_INIT(file_open, medusa_l1_file_open),
 
 	//LSM_HOOK_INIT(dentry_open, medusa_l1_dentry_open),
 
@@ -1564,30 +1564,30 @@ static struct security_hook_list medusa_l1_hooks[] = {
 	//LSM_HOOK_INIT(task_prctl, medusa_l1_task_prctl),
 	//LSM_HOOK_INIT(task_to_inode, medusa_l1_task_to_inode),
 
-	// LSM_HOOK_INIT(ipc_permission, medusa_l1_ipc_permission),
+	LSM_HOOK_INIT(ipc_permission, medusa_l1_ipc_permission),
 	// LSM_HOOK_INIT(ipc_getsecid, medusa_l1_ipc_getsecid),
 
-	// LSM_HOOK_INIT(msg_msg_alloc_security, medusa_l1_msg_msg_alloc_security),
-	// LSM_HOOK_INIT(msg_msg_free_security, medusa_l1_msg_msg_free_security),
+	LSM_HOOK_INIT(msg_msg_alloc_security, medusa_l1_msg_msg_alloc_security),
+	LSM_HOOK_INIT(msg_msg_free_security, medusa_l1_msg_msg_free_security),
 
 	// msg_queue_alloc_security --> medusa_l1_msg_queue_alloc_security: transfered to medusa_l1_special
 	// msg_queue_free_security --> medusa_l1_msg_queue_free_security: transfered to medusa_l1_special
-	// LSM_HOOK_INIT(msg_queue_associate, medusa_l1_msg_queue_associate),
-	// LSM_HOOK_INIT(msg_queue_msgctl, medusa_l1_msg_queue_msgctl),
-	// LSM_HOOK_INIT(msg_queue_msgsnd, medusa_l1_msg_queue_msgsnd),
-	// LSM_HOOK_INIT(msg_queue_msgrcv, medusa_l1_msg_queue_msgrcv),
+	LSM_HOOK_INIT(msg_queue_associate, medusa_l1_msg_queue_associate),
+	LSM_HOOK_INIT(msg_queue_msgctl, medusa_l1_msg_queue_msgctl),
+	LSM_HOOK_INIT(msg_queue_msgsnd, medusa_l1_msg_queue_msgsnd),
+	LSM_HOOK_INIT(msg_queue_msgrcv, medusa_l1_msg_queue_msgrcv),
 
 	// shm_alloc_security --> medusa_l1_shm_alloc_security: transfered to medusa_l1_special
 	// shm_free_security --> medusa_l1_shm_free_security: transfered to medusa_l1_special
-	// LSM_HOOK_INIT(shm_associate, medusa_l1_shm_associate),
-	// LSM_HOOK_INIT(shm_shmctl, medusa_l1_shm_shmctl),
-	// LSM_HOOK_INIT(shm_shmat, medusa_l1_shm_shmat),
+	LSM_HOOK_INIT(shm_associate, medusa_l1_shm_associate),
+	LSM_HOOK_INIT(shm_shmctl, medusa_l1_shm_shmctl),
+	LSM_HOOK_INIT(shm_shmat, medusa_l1_shm_shmat),
 
 	// sem_alloc_security --> medusa_l1_sem_alloc_security: transfered to medusa_l1_special
 	// sem_free_security --> medusa_l1_sem_free_security: transfered to medusa_l1_special
-	// LSM_HOOK_INIT(sem_associate, medusa_l1_sem_associate),
-	// LSM_HOOK_INIT(sem_semctl, medusa_l1_sem_semctl),
-	// LSM_HOOK_INIT(sem_semop, medusa_l1_sem_semop),
+	LSM_HOOK_INIT(sem_associate, medusa_l1_sem_associate),
+	LSM_HOOK_INIT(sem_semctl, medusa_l1_sem_semctl),
+	LSM_HOOK_INIT(sem_semop, medusa_l1_sem_semop),
 
 	//LSM_HOOK_INIT(netlink_send, medusa_l1_netlink_send),
 

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -1482,7 +1482,7 @@ static struct security_hook_list medusa_l1_hooks[] = {
 
 #ifdef CONFIG_SECURITY_PATH
 	LSM_HOOK_INIT(path_unlink, medusa_l1_path_unlink),
-	//LSM_HOOK_INIT(path_mkdir, medusa_l1_path_mkdir),
+	LSM_HOOK_INIT(path_mkdir, medusa_l1_path_mkdir),
 	// LSM_HOOK_INIT(path_rmdir, medusa_l1_path_rmdir),
 	//LSM_HOOK_INIT(path_mknod, medusa_l1_path_mknod),
 	//LSM_HOOK_INIT(path_truncate, medusa_l1_path_truncate),

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -376,6 +376,12 @@ static int medusa_l1_path_mknod(const struct path *dir, struct dentry *dentry,
 static int medusa_l1_path_mkdir(const struct path *dir, struct dentry *dentry,
 				umode_t mode)
 {
+	char buf[128];
+	char *pos = d_absolute_path(dir, buf, 127);
+	if (!IS_ERR(pos))
+		med_pr_info("mkdir: %s", pos);
+	if (medusa_mkdir(dir, dentry, mode) == MED_NO)
+		return -EPERM;
 	return 0;
 }
 
@@ -392,6 +398,10 @@ static int medusa_l1_path_rmdir(const struct path *dir, struct dentry *dentry)
 
 static int medusa_l1_path_unlink(const struct path *dir, struct dentry *dentry)
 {
+	char buf[128];
+	char *pos = d_absolute_path(dir, buf, 127);
+	if (!IS_ERR(pos))
+		med_pr_info("unlink: %s", pos);
 	if (medusa_unlink(dir, dentry) == MED_NO)
 		return -EPERM;
 	return 0;
@@ -1473,28 +1483,28 @@ static struct security_hook_list medusa_l1_hooks[] = {
 #ifdef CONFIG_SECURITY_PATH
 	LSM_HOOK_INIT(path_unlink, medusa_l1_path_unlink),
 	//LSM_HOOK_INIT(path_mkdir, medusa_l1_path_mkdir),
-	LSM_HOOK_INIT(path_rmdir, medusa_l1_path_rmdir),
+	// LSM_HOOK_INIT(path_rmdir, medusa_l1_path_rmdir),
 	//LSM_HOOK_INIT(path_mknod, medusa_l1_path_mknod),
 	//LSM_HOOK_INIT(path_truncate, medusa_l1_path_truncate),
 	//LSM_HOOK_INIT(path_symlink, medusa_l1_path_symlink),
 	// mY LSM_HOOK_INIT(path_link, medusa_l1_path_link),
-	LSM_HOOK_INIT(path_rename, medusa_l1_path_rename),
+	// LSM_HOOK_INIT(path_rename, medusa_l1_path_rename),
 	// mY LSM_HOOK_INIT(path_chmod, medusa_l1_path_chmod),
 	// mY LSM_HOOK_INIT(path_chown, medusa_l1_path_chown),
 	//LSM_HOOK_INIT(path_chroot, medusa_l1_path_chroot),
 
 #endif /* CONFIG_SECURITY_PATH */
 	//LSM_HOOK_INIT(inode_init_security, medusa_l1_inode_init_security),
-	LSM_HOOK_INIT(inode_create, medusa_l1_inode_create),
-	LSM_HOOK_INIT(inode_link, medusa_l1_inode_link),
-	LSM_HOOK_INIT(inode_symlink, medusa_l1_inode_symlink),
-	//LSM_HOOK_INIT(inode_mkdir, medusa_l1_inode_mkdir),
+	// LSM_HOOK_INIT(inode_create, medusa_l1_inode_create),
+	// LSM_HOOK_INIT(inode_mkdir, medusa_l1_inode_mkdir),
+	// LSM_HOOK_INIT(inode_link, medusa_l1_inode_link),
+	// LSM_HOOK_INIT(inode_symlink, medusa_l1_inode_symlink),
 	// LSM_HOOK_INIT(inode_rmdir, medusa_l1_inode_rmdir),
-	LSM_HOOK_INIT(inode_mknod, medusa_l1_inode_mknod),
+	// LSM_HOOK_INIT(inode_mknod, medusa_l1_inode_mknod),
 	//LSM_HOOK_INIT(inode_rename, medusa_l1_inode_rename),
-	LSM_HOOK_INIT(inode_readlink, medusa_l1_inode_readlink),
+	// LSM_HOOK_INIT(inode_readlink, medusa_l1_inode_readlink),
 	//LSM_HOOK_INIT(inode_follow_link, medusa_l1_inode_follow_link),
-	LSM_HOOK_INIT(inode_permission, medusa_l1_inode_permission),
+	// LSM_HOOK_INIT(inode_permission, medusa_l1_inode_permission),
 	//LSM_HOOK_INIT(inode_setattr, medusa_l1_inode_setattr),
 	//LSM_HOOK_INIT(inode_getattr, medusa_l1_inode_getattr),
 	//LSM_HOOK_INIT(inode_setxattr, medusa_l1_inode_setxattr),
@@ -1521,7 +1531,7 @@ static struct security_hook_list medusa_l1_hooks[] = {
 	//LSM_HOOK_INIT(file_set_fowner, medusa_l1_file_set_fowner),
 	//LSM_HOOK_INIT(file_send_sigiotask, medusa_l1_file_send_sigiotask),
 	//LSM_HOOK_INIT(file_receive, medusa_l1_file_receive),
-	LSM_HOOK_INIT(file_open, medusa_l1_file_open),
+	// LSM_HOOK_INIT(file_open, medusa_l1_file_open),
 
 	//LSM_HOOK_INIT(dentry_open, medusa_l1_dentry_open),
 
@@ -1551,30 +1561,30 @@ static struct security_hook_list medusa_l1_hooks[] = {
 	//LSM_HOOK_INIT(task_prctl, medusa_l1_task_prctl),
 	//LSM_HOOK_INIT(task_to_inode, medusa_l1_task_to_inode),
 
-	LSM_HOOK_INIT(ipc_permission, medusa_l1_ipc_permission),
+	// LSM_HOOK_INIT(ipc_permission, medusa_l1_ipc_permission),
 	// LSM_HOOK_INIT(ipc_getsecid, medusa_l1_ipc_getsecid),
 
-	LSM_HOOK_INIT(msg_msg_alloc_security, medusa_l1_msg_msg_alloc_security),
-	LSM_HOOK_INIT(msg_msg_free_security, medusa_l1_msg_msg_free_security),
+	// LSM_HOOK_INIT(msg_msg_alloc_security, medusa_l1_msg_msg_alloc_security),
+	// LSM_HOOK_INIT(msg_msg_free_security, medusa_l1_msg_msg_free_security),
 
 	// msg_queue_alloc_security --> medusa_l1_msg_queue_alloc_security: transfered to medusa_l1_special
 	// msg_queue_free_security --> medusa_l1_msg_queue_free_security: transfered to medusa_l1_special
-	LSM_HOOK_INIT(msg_queue_associate, medusa_l1_msg_queue_associate),
-	LSM_HOOK_INIT(msg_queue_msgctl, medusa_l1_msg_queue_msgctl),
-	LSM_HOOK_INIT(msg_queue_msgsnd, medusa_l1_msg_queue_msgsnd),
-	LSM_HOOK_INIT(msg_queue_msgrcv, medusa_l1_msg_queue_msgrcv),
+	// LSM_HOOK_INIT(msg_queue_associate, medusa_l1_msg_queue_associate),
+	// LSM_HOOK_INIT(msg_queue_msgctl, medusa_l1_msg_queue_msgctl),
+	// LSM_HOOK_INIT(msg_queue_msgsnd, medusa_l1_msg_queue_msgsnd),
+	// LSM_HOOK_INIT(msg_queue_msgrcv, medusa_l1_msg_queue_msgrcv),
 
 	// shm_alloc_security --> medusa_l1_shm_alloc_security: transfered to medusa_l1_special
 	// shm_free_security --> medusa_l1_shm_free_security: transfered to medusa_l1_special
-	LSM_HOOK_INIT(shm_associate, medusa_l1_shm_associate),
-	LSM_HOOK_INIT(shm_shmctl, medusa_l1_shm_shmctl),
-	LSM_HOOK_INIT(shm_shmat, medusa_l1_shm_shmat),
+	// LSM_HOOK_INIT(shm_associate, medusa_l1_shm_associate),
+	// LSM_HOOK_INIT(shm_shmctl, medusa_l1_shm_shmctl),
+	// LSM_HOOK_INIT(shm_shmat, medusa_l1_shm_shmat),
 
 	// sem_alloc_security --> medusa_l1_sem_alloc_security: transfered to medusa_l1_special
 	// sem_free_security --> medusa_l1_sem_free_security: transfered to medusa_l1_special
-	LSM_HOOK_INIT(sem_associate, medusa_l1_sem_associate),
-	LSM_HOOK_INIT(sem_semctl, medusa_l1_sem_semctl),
-	LSM_HOOK_INIT(sem_semop, medusa_l1_sem_semop),
+	// LSM_HOOK_INIT(sem_associate, medusa_l1_sem_associate),
+	// LSM_HOOK_INIT(sem_semctl, medusa_l1_sem_semctl),
+	// LSM_HOOK_INIT(sem_semop, medusa_l1_sem_semop),
 
 	//LSM_HOOK_INIT(netlink_send, medusa_l1_netlink_send),
 

--- a/security/medusa/l1/medusa.c
+++ b/security/medusa/l1/medusa.c
@@ -12,6 +12,7 @@
 #include "l1/ipc.h"
 #include "l1/socket.h"
 #include "l1/fuck.h"
+#include "../../../../fs/mount.h" /* real_mount(), struct mount */
 
 int medusa_l1_inode_alloc_security(struct inode *inode);
 
@@ -292,7 +293,7 @@ static int medusa_l1_inode_permission(struct inode *inode, int mask)
 	if (no_block)
 		return -ECHILD;
 
-	mask &= (MAY_READ|MAY_WRITE|MAY_EXEC|MAY_APPEND);*/
+	mask &= (MAY_READ|MAY_WRITE|MAY_EXEC|MAY_APPEND);
 	/*
 	 * Existence test.
 	 * TODO What about Medusa SEE permission?

--- a/security/medusa/l2/acctype_create.c
+++ b/security/medusa/l2/acctype_create.c
@@ -63,7 +63,7 @@ enum medusa_answer_t medusa_create(struct dentry *dentry, int mode)
 	medusa_get_upper_and_parent(&ndcurrent, &ndupper, &ndparent);
 
 	if (!is_med_magic_valid(&(inode_security(ndparent.dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(ndparent.dentry, ndparent.mnt) <= 0) {
+		file_kobj_validate_dentry(ndparent.dentry, ndparent.mnt, NULL) <= 0) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_ALLOW;
 	}

--- a/security/medusa/l2/acctype_exec.c
+++ b/security/medusa/l2/acctype_exec.c
@@ -88,7 +88,7 @@ enum medusa_answer_t medusa_exec(struct dentry **dentryp)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security((*dentryp)->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(*dentryp, NULL) <= 0)
+		file_kobj_validate_dentry(*dentryp, NULL, NULL) <= 0)
 		return MED_ALLOW;
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security((*dentryp)->d_inode))) ||
 		!vs_intersects(VSR(task_security(current)), VS(inode_security((*dentryp)->d_inode)))

--- a/security/medusa/l2/acctype_link.c
+++ b/security/medusa/l2/acctype_link.c
@@ -60,7 +60,7 @@ enum medusa_answer_t medusa_link(struct dentry *dentry, const char *newname)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0) {
+		file_kobj_validate_dentry(dentry, NULL, NULL) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_lookup.c
+++ b/security/medusa/l2/acctype_lookup.c
@@ -50,7 +50,7 @@ enum medusa_answer_t medusa_lookup(struct inode *dir, struct dentry **dentry)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security((*dentry)->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(*dentry, NULL) <= 0)
+		file_kobj_validate_dentry(*dentry, NULL, NULL) <= 0)
 		return MED_ALLOW;
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security((*dentry)->d_inode))))
 		return MED_DENY;

--- a/security/medusa/l2/acctype_mkdir.c
+++ b/security/medusa/l2/acctype_mkdir.c
@@ -60,7 +60,7 @@ enum medusa_answer_t medusa_mkdir(const struct path *dir, struct dentry *dentry,
 	medusa_get_upper_and_parent(&ndcurrent, &ndupper, NULL);
 
 	if (!is_med_magic_valid(&(inode_security(ndupper.dentry->d_inode)->med_object)) &&
-		file_kobj_validate_dentry_dir(&ndupper, ndupper.dentry) <= 0) {
+		file_kobj_validate_dentry_dir(ndupper.mnt, ndupper.dentry) <= 0) {
 		medusa_put_upper_and_parent(&ndupper, NULL);
 		return MED_ALLOW;
 	}

--- a/security/medusa/l2/acctype_mkdir.c
+++ b/security/medusa/l2/acctype_mkdir.c
@@ -28,7 +28,7 @@ int __init mkdir_acctype_init(void)
 }
 
 /* XXX Don't try to inline this. GCC tries to be too smart about stack. */
-static medusa_answer_t medusa_do_mkdir(const struct path * dir, struct dentry *dentry, int mode)
+static enum medusa_answer_t medusa_do_mkdir(const struct path *dir, struct dentry *dentry, int mode)
 {
 	struct mkdir_access access;
 	struct process_kobject process;

--- a/security/medusa/l2/acctype_mkdir.c
+++ b/security/medusa/l2/acctype_mkdir.c
@@ -60,19 +60,19 @@ enum medusa_answer_t medusa_mkdir(const struct path *dir, struct dentry *dentry,
 	//ndcurrent.mnt = NULL;
 	//medusa_get_upper_and_parent(&ndcurrent,&ndupper,&ndparent);
 
-	if (!is_med_magic_valid(&(inode_security(parent->dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(parent->dentry, parent->mnt) <= 0) {
+	if (!is_med_magic_valid(&(inode_security(dir->dentry->d_inode)->med_object)) &&
+		file_kobj_validate_dentry(dir->dentry, dir->mnt, NULL) <= 0) {
 		// medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_ALLOW;
 	}
-	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(parent->dentry->d_inode))) ||
-		!vs_intersects(VSW(task_security(current)), VS(inode_security(parent->dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dir->dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)), VS(inode_security(dir->dentry->d_inode)))
 	) {
 		//medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_DENY;
 	}
-	if (MEDUSA_MONITORED_ACCESS_O(mkdir_access, inode_security(parent->dentry->d_inode)))
-		retval = medusa_do_mkdir(parent->dentry, dentry, mode);
+	if (MEDUSA_MONITORED_ACCESS_O(mkdir_access, inode_security(dir->dentry->d_inode)))
+		retval = medusa_do_mkdir(dir->dentry, dentry, mode);
 	else
 		retval = MED_ALLOW;
 	//medusa_put_upper_and_parent(&ndupper, &ndparent);

--- a/security/medusa/l2/acctype_mkdir.c
+++ b/security/medusa/l2/acctype_mkdir.c
@@ -28,7 +28,7 @@ int __init mkdir_acctype_init(void)
 }
 
 /* XXX Don't try to inline this. GCC tries to be too smart about stack. */
-static enum medusa_answer_t medusa_do_mkdir(struct dentry *parent, struct dentry *dentry, int mode)
+static medusa_answer_t medusa_do_mkdir(struct dentry * dir, struct dentry *dentry, int mode)
 {
 	struct mkdir_access access;
 	struct process_kobject process;
@@ -38,14 +38,14 @@ static enum medusa_answer_t medusa_do_mkdir(struct dentry *parent, struct dentry
 	file_kobj_dentry2string(dentry, access.filename);
 	access.mode = mode;
 	process_kern2kobj(&process, current);
-	file_kern2kobj(&file, parent->d_inode);
-	file_kobj_live_add(parent->d_inode);
+	file_kern2kobj(&file, dir->d_inode);
+	file_kobj_live_add(dir->d_inode);
 	retval = MED_DECIDE(mkdir_access, &access, &process, &file);
-	file_kobj_live_remove(parent->d_inode);
+	file_kobj_live_remove(dir->d_inode);
 	return retval;
 }
 
-enum medusa_answer_t medusa_mkdir(const struct path *parent, struct dentry *dentry, int mode)
+enum medusa_answer_t medusa_mkdir(const struct path *dir, struct dentry *dentry, int mode)
 {
 	//struct path ndcurrent, ndupper, ndparent;
 	enum medusa_answer_t retval;
@@ -77,6 +77,21 @@ enum medusa_answer_t medusa_mkdir(const struct path *parent, struct dentry *dent
 		retval = MED_ALLOW;
 	//medusa_put_upper_and_parent(&ndupper, &ndparent);
 	return retval;
+	/*if (!MED_MAGIC_VALID(&inode_security(dir->dentry->d_inode)) &&
+//	        file_kobj_validate_dentry_dir(&parent,dir->dentry) <= 0) {
+			file_kobj_validate_dentry(dir->dentry,dir->mnt, dir) <= 0) {
+		return MED_OK;
+	}*/
+/*	if (!VS_INTERSECT(VSS(&task_security(current)),VS(&inode_security(dir->dentry->d_inode))) ||
+		!VS_INTERSECT(VSW(&task_security(current)),VS(&inode_security(dir->dentry->d_inode)))
+	) {
+		return MED_NO;
+	}
+	if (MEDUSA_MONITORED_ACCESS_O(mkdir_access, &inode_security(dir->dentry->d_inode)))
+		retval = medusa_do_mkdir(dir->dentry, dentry, mode);
+	else
+		retval = MED_OK;
+	return retval;*/
 }
 
 device_initcall(mkdir_acctype_init);

--- a/security/medusa/l2/acctype_mknod.c
+++ b/security/medusa/l2/acctype_mknod.c
@@ -30,27 +30,28 @@ int __init mknod_acctype_init(void)
 }
 
 /* XXX Don't try to inline this. GCC tries to be too smart about stack. */
-static enum medusa_answer_t medusa_do_mknod(struct dentry *parent, struct dentry *dentry, dev_t dev, int mode)
+static enum medusa_answer_t medusa_do_mknod(const struct path *dir, struct dentry *dentry, int mode, dev_t dev)
 {
 	struct mknod_access access;
 	struct process_kobject process;
 	struct file_kobject file;
 	enum medusa_answer_t retval;
 
-	file_kobj_dentry2string(dentry, access.filename);
+	file_kobj_dentry2string_mnt(dir, dentry, access.filename);
 	access.dev = dev;
 	access.mode = mode;
 	process_kern2kobj(&process, current);
-	file_kern2kobj(&file, parent->d_inode);
-	file_kobj_live_add(parent->d_inode);
+	file_kern2kobj(&file, dir->dentry->d_inode);
+	file_kobj_live_add(dir->dentry->d_inode);
 	retval = MED_DECIDE(mknod_access, &access, &process, &file);
-	file_kobj_live_remove(parent->d_inode);
+	file_kobj_live_remove(dir->dentry->d_inode);
 	return retval;
 }
 
-enum medusa_answer_t medusa_mknod(struct dentry *dentry, dev_t dev, int mode)
+enum medusa_answer_t medusa_mknod(const struct path *dir, struct dentry *dentry, umode_t mode,
+			unsigned int dev)
 {
-	struct path ndcurrent, ndupper, ndparent;
+	struct path ndcurrent, ndupper;
 	enum medusa_answer_t retval;
 
 	if (!dentry || IS_ERR(dentry))
@@ -59,26 +60,25 @@ enum medusa_answer_t medusa_mknod(struct dentry *dentry, dev_t dev, int mode)
 		process_kobj_validate_task(current) <= 0)
 		return MED_ALLOW;
 
-	ndcurrent.dentry = dentry;
-	ndcurrent.mnt = NULL;
-	medusa_get_upper_and_parent(&ndcurrent, &ndupper, &ndparent);
+	ndcurrent = *dir;
+	medusa_get_upper_and_parent(&ndcurrent, &ndupper, NULL);
 
-	if (!is_med_magic_valid(&(inode_security(ndparent.dentry->d_inode)->med_object)) &&
-		file_kobj_validate_dentry(ndparent.dentry,ndparent.mnt,NULL) <= 0) {
-		medusa_put_upper_and_parent(&ndupper, &ndparent);
+	if (!is_med_magic_valid(&(inode_security(ndupper.dentry->d_inode)->med_object)) &&
+		file_kobj_validate_dentry(ndupper.dentry, ndupper.mnt, NULL) <= 0) {
+		medusa_put_upper_and_parent(&ndupper, NULL);
 		return MED_ALLOW;
 	}
-	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(ndparent.dentry->d_inode))) ||
-		!vs_intersects(VSW(task_security(current)), VS(inode_security(ndparent.dentry->d_inode)))
+	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(ndupper.dentry->d_inode))) ||
+		!vs_intersects(VSW(task_security(current)), VS(inode_security(ndupper.dentry->d_inode)))
 	) {
-		medusa_put_upper_and_parent(&ndupper, &ndparent);
+		medusa_put_upper_and_parent(&ndupper, NULL);
 		return MED_DENY;
 	}
-	if (MEDUSA_MONITORED_ACCESS_O(mknod_access, inode_security(ndparent.dentry->d_inode)))
-		retval = medusa_do_mknod(ndparent.dentry, ndupper.dentry, dev, mode);
+	if (MEDUSA_MONITORED_ACCESS_O(mknod_access, inode_security(ndupper.dentry->d_inode)))
+		retval = medusa_do_mknod(&ndupper, dentry, mode, dev);
 	else
 		retval = MED_ALLOW;
-	medusa_put_upper_and_parent(&ndupper, &ndparent);
+	medusa_put_upper_and_parent(&ndupper, NULL);
 	return retval;
 }
 

--- a/security/medusa/l2/acctype_mknod.c
+++ b/security/medusa/l2/acctype_mknod.c
@@ -64,7 +64,7 @@ enum medusa_answer_t medusa_mknod(struct dentry *dentry, dev_t dev, int mode)
 	medusa_get_upper_and_parent(&ndcurrent, &ndupper, &ndparent);
 
 	if (!is_med_magic_valid(&(inode_security(ndparent.dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(ndparent.dentry,ndparent.mnt) <= 0) {
+		file_kobj_validate_dentry(ndparent.dentry,ndparent.mnt,NULL) <= 0) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_ALLOW;
 	}

--- a/security/medusa/l2/acctype_notify_change.c
+++ b/security/medusa/l2/acctype_notify_change.c
@@ -73,7 +73,7 @@ enum medusa_answer_t medusa_notify_change(struct dentry *dentry, struct iattr *a
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0)
+		file_kobj_validate_dentry(dentry, NULL, NULL) <= 0)
 		return MED_ALLOW;
 
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_permission.c
+++ b/security/medusa/l2/acctype_permission.c
@@ -63,7 +63,7 @@ enum medusa_answer_t medusa_permission(struct inode *inode, int mask)
 	if (!dentry || IS_ERR(dentry))
 		return retval;
 	if (!is_med_magic_valid(&(inode_security(inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0)
+		file_kobj_validate_dentry(dentry, NULL, NULL) <= 0)
 		goto out_dput;
 	if (
 		!vs_intersects(VSS(task_security(current)), VS(inode_security(inode))) ||

--- a/security/medusa/l2/acctype_readlink.c
+++ b/security/medusa/l2/acctype_readlink.c
@@ -51,7 +51,7 @@ enum medusa_answer_t medusa_readlink(struct dentry *dentry)
 			process_kobj_validate_task(current) <= 0)
 		return MED_ALLOW;
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0) {
+		file_kobj_validate_dentry(dentry, NULL, NULL) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_readwrite.c
+++ b/security/medusa/l2/acctype_readwrite.c
@@ -25,7 +25,7 @@ enum medusa_answer_t medusa_read(struct file *file)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0)
+		file_kobj_validate_dentry(dentry, NULL, NULL) <= 0)
 		return MED_ALLOW;
 	if (
 		!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||
@@ -54,7 +54,7 @@ enum medusa_answer_t medusa_write(struct file *file)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0)
+		file_kobj_validate_dentry(dentry, NULL, NULL) <= 0)
 		return MED_ALLOW;
 	if (
 		!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_rename.c
+++ b/security/medusa/l2/acctype_rename.c
@@ -62,7 +62,7 @@ enum medusa_answer_t medusa_rename(struct dentry *dentry, const char *newname)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0) {
+		file_kobj_validate_dentry(dentry, NULL, NULL) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_rmdir.c
+++ b/security/medusa/l2/acctype_rmdir.c
@@ -53,7 +53,7 @@ enum medusa_answer_t medusa_rmdir(const struct path *dir, struct dentry *dentry)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry_dir(dir, dentry) <= 0) {
+		file_kobj_validate_dentry_dir(dir, dentry) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_rmdir.c
+++ b/security/medusa/l2/acctype_rmdir.c
@@ -53,7 +53,7 @@ enum medusa_answer_t medusa_rmdir(const struct path *dir, struct dentry *dentry)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-		file_kobj_validate_dentry_dir(dir, dentry) <= 0) {
+		file_kobj_validate_dentry_dir(dir->mnt, dentry) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_rmdir.c
+++ b/security/medusa/l2/acctype_rmdir.c
@@ -53,7 +53,7 @@ enum medusa_answer_t medusa_rmdir(const struct path *dir, struct dentry *dentry)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0) {
+			file_kobj_validate_dentry_dir(dir, dentry) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_rmdir.c
+++ b/security/medusa/l2/acctype_rmdir.c
@@ -26,14 +26,14 @@ int __init rmdir_acctype_init(void)
 }
 
 /* XXX Don't try to inline this. GCC tries to be too smart about stack. */
-static enum medusa_answer_t medusa_do_rmdir(struct dentry *dentry)
+static enum medusa_answer_t medusa_do_rmdir(const struct path *dir, struct dentry *dentry)
 {
 	struct rmdir_access access;
 	struct process_kobject process;
 	struct file_kobject file;
 	enum medusa_answer_t retval;
 
-	file_kobj_dentry2string(dentry, access.filename);
+	file_kobj_dentry2string_dir(dir, dentry, access.filename);
 	process_kern2kobj(&process, current);
 	file_kern2kobj(&file, dentry->d_inode);
 	file_kobj_live_add(dentry->d_inode);
@@ -61,7 +61,7 @@ enum medusa_answer_t medusa_rmdir(const struct path *dir, struct dentry *dentry)
 	)
 		return MED_DENY;
 	if (MEDUSA_MONITORED_ACCESS_O(rmdir_access, inode_security(dentry->d_inode)))
-		return medusa_do_rmdir(dentry);
+		return medusa_do_rmdir(dir, dentry);
 	return MED_ALLOW;
 }
 

--- a/security/medusa/l2/acctype_rmdir.c
+++ b/security/medusa/l2/acctype_rmdir.c
@@ -33,7 +33,7 @@ static enum medusa_answer_t medusa_do_rmdir(const struct path *dir, struct dentr
 	struct file_kobject file;
 	enum medusa_answer_t retval;
 
-	file_kobj_dentry2string_dir(dir, dentry, access.filename);
+	file_kobj_dentry2string_mnt(dir, dentry, access.filename);
 	process_kern2kobj(&process, current);
 	file_kern2kobj(&file, dentry->d_inode);
 	file_kobj_live_add(dentry->d_inode);

--- a/security/medusa/l2/acctype_sexec.c
+++ b/security/medusa/l2/acctype_sexec.c
@@ -77,7 +77,7 @@ enum medusa_answer_t medusa_sexec(struct linux_binprm *bprm)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(DENTRY->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(DENTRY, bprm->file->f_path.mnt) <= 0)
+		file_kobj_validate_dentry(DENTRY, bprm->file->f_path.mnt, NULL) <= 0)
 		return MED_ALLOW;
 	/* no sense in checking VS here */
 	if (MEDUSA_MONITORED_ACCESS_S(sexec_access, task_security(current)))

--- a/security/medusa/l2/acctype_symlink.c
+++ b/security/medusa/l2/acctype_symlink.c
@@ -66,10 +66,10 @@ enum medusa_answer_t medusa_symlink(struct dentry *dentry, const char *oldname)
 	ndcurrent.mnt = NULL;
 	medusa_get_upper_and_parent(&ndcurrent, &ndupper, &ndparent);
 
-	file_kobj_validate_dentry(ndparent.dentry, ndparent.mnt);
+	file_kobj_validate_dentry(ndparent.dentry, ndparent.mnt, NULL);
 
 	if (!is_med_magic_valid(&(inode_security(ndparent.dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(ndparent.dentry, ndparent.mnt) <= 0) {
+		file_kobj_validate_dentry(ndparent.dentry, ndparent.mnt, NULL) <= 0) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
 		return MED_ALLOW;
 	}

--- a/security/medusa/l2/acctype_truncate.c
+++ b/security/medusa/l2/acctype_truncate.c
@@ -54,7 +54,7 @@ enum medusa_answer_t medusa_truncate(struct dentry *dentry, unsigned long length
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0)
+		file_kobj_validate_dentry(dentry, NULL, NULL) <= 0)
 		return MED_ALLOW;
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||
 		!vs_intersects(VSW(task_security(current)), VS(inode_security(dentry->d_inode)))

--- a/security/medusa/l2/acctype_unlink.c
+++ b/security/medusa/l2/acctype_unlink.c
@@ -52,7 +52,7 @@ enum medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-		file_kobj_validate_dentry_dir(dir, dentry) <= 0) {
+		file_kobj_validate_dentry_dir(dir->mnt, dentry) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_unlink.c
+++ b/security/medusa/l2/acctype_unlink.c
@@ -26,14 +26,14 @@ int __init unlink_acctype_init(void)
 }
 
 /* XXX Don't try to inline this. GCC tries to be too smart about stack. */
-static enum medusa_answer_t medusa_do_unlink(struct dentry *dentry)
+static medusa_answer_t medusa_do_unlink(const struct path *dir, struct dentry *dentry)
 {
 	struct unlink_access access;
 	struct process_kobject process;
 	struct file_kobject file;
 	enum medusa_answer_t retval;
 
-	file_kobj_dentry2string(dentry, access.filename);
+	file_kobj_dentry2string_mnt(dir, dentry, access.filename);
 	process_kern2kobj(&process, current);
 	file_kern2kobj(&file, dentry->d_inode);
 	file_kobj_live_add(dentry->d_inode);
@@ -42,7 +42,8 @@ static enum medusa_answer_t medusa_do_unlink(struct dentry *dentry)
 	return retval;
 }
 
-medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry)
+static medusa_answer_t medusa_do_unlink(const struct path *dir, struct dentry *dentry);
+enum medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry)
 {
 	if (!dentry || IS_ERR(dentry) || dentry->d_inode == NULL)
 		return MED_ALLOW;
@@ -60,7 +61,7 @@ medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry)
 	)
 		return MED_DENY;
 	if (MEDUSA_MONITORED_ACCESS_O(unlink_access, inode_security(dentry->d_inode)))
-		return medusa_do_unlink(dentry);
+		return medusa_do_unlink(dir, dentry);
 	return MED_ALLOW;
 }
 

--- a/security/medusa/l2/acctype_unlink.c
+++ b/security/medusa/l2/acctype_unlink.c
@@ -42,7 +42,7 @@ static enum medusa_answer_t medusa_do_unlink(struct dentry *dentry)
 	return retval;
 }
 
-enum medusa_answer_t medusa_unlink(struct dentry *dentry)
+medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry)
 {
 	if (!dentry || IS_ERR(dentry) || dentry->d_inode == NULL)
 		return MED_ALLOW;
@@ -52,7 +52,7 @@ enum medusa_answer_t medusa_unlink(struct dentry *dentry)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, NULL) <= 0) {
+			file_kobj_validate_dentry(dentry, dir) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_unlink.c
+++ b/security/medusa/l2/acctype_unlink.c
@@ -52,7 +52,7 @@ medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-	    file_kobj_validate_dentry_dir(dir, dentry) <= 0) {
+		file_kobj_validate_dentry_dir(dir, dentry,NULL) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_unlink.c
+++ b/security/medusa/l2/acctype_unlink.c
@@ -52,7 +52,7 @@ medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-		file_kobj_validate_dentry_dir(dir, dentry,NULL) <= 0) {
+		file_kobj_validate_dentry_dir(dir, dentry) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_unlink.c
+++ b/security/medusa/l2/acctype_unlink.c
@@ -52,7 +52,7 @@ medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry)
 		return MED_ALLOW;
 
 	if (!is_med_magic_valid(&(inode_security(dentry->d_inode)->med_object)) &&
-			file_kobj_validate_dentry(dentry, dir) <= 0) {
+	    file_kobj_validate_dentry_dir(dir, dentry) <= 0) {
 		return MED_ALLOW;
 	}
 	if (!vs_intersects(VSS(task_security(current)), VS(inode_security(dentry->d_inode))) ||

--- a/security/medusa/l2/acctype_unlink.c
+++ b/security/medusa/l2/acctype_unlink.c
@@ -26,7 +26,7 @@ int __init unlink_acctype_init(void)
 }
 
 /* XXX Don't try to inline this. GCC tries to be too smart about stack. */
-static medusa_answer_t medusa_do_unlink(const struct path *dir, struct dentry *dentry)
+static enum medusa_answer_t medusa_do_unlink(const struct path *dir, struct dentry *dentry)
 {
 	struct unlink_access access;
 	struct process_kobject process;
@@ -42,7 +42,6 @@ static medusa_answer_t medusa_do_unlink(const struct path *dir, struct dentry *d
 	return retval;
 }
 
-static medusa_answer_t medusa_do_unlink(const struct path *dir, struct dentry *dentry);
 enum medusa_answer_t medusa_unlink(const struct path *dir, struct dentry *dentry)
 {
 	if (!dentry || IS_ERR(dentry) || dentry->d_inode == NULL)

--- a/security/medusa/l2/evtype_getfile.c
+++ b/security/medusa/l2/evtype_getfile.c
@@ -127,6 +127,7 @@ void inline info_mnt(struct mount *mnt)
 void medusa_get_upper_and_parent(struct path *ndsource,
 		struct path *ndupperp, struct path *ndparentp)
 {
+	pr_info("medusa_get_upper_and_parent: dentry %pd4\n", ndsource->dentry);
 	*ndupperp = *ndsource;
 	dget(ndupperp->dentry);
 	if (ndupperp->mnt) {
@@ -146,6 +147,7 @@ void medusa_get_upper_and_parent(struct path *ndsource,
 		if (real_mount(ndupperp->mnt)->mnt_parent == real_mount(ndupperp->mnt)->mnt_parent->mnt_parent) {
 			/* Cyklus skonci, ked rodic mountpointu uz nema dalsieho
 			 * rodica, resp. su totozne. */
+			pr_info("medusa_get_upper_and_parent: at root: %pd4, source: %pd4\n", real_mount(ndupperp->mnt)->mnt_parent->mnt_mountpoint, ndsource->dentry);
 			break;
 		}
 		/* Prechod na vyssi mountpoint, najprv dentry pre mountpoint */

--- a/security/medusa/l2/evtype_getfile.c
+++ b/security/medusa/l2/evtype_getfile.c
@@ -247,7 +247,7 @@ struct path check(struct dentry* dentry, struct path* dir, struct path* c, struc
 			.dentry = ndparent.dentry->d_parent};
 }
 
-int file_kobj_validate_dentry_dir(struct dentry *dentry, const struct path* dir)
+int file_kobj_validate_dentry_dir(const struct path* dir, struct dentry *dentry)
 {
 	struct path ndcurrent;
 	struct path ndupper;
@@ -282,7 +282,7 @@ int file_kobj_validate_dentry_dir(struct dentry *dentry, const struct path* dir)
 		parent_dir = (struct path) {.mnt = ndparent.mnt,
 			                    .dentry = ndparent.dentry->d_parent};
 		if (!MED_MAGIC_VALID(&inode_security(ndparent.dentry->d_inode)) &&
-			file_kobj_validate_dentry_dir(ndparent.dentry, &parent_dir) <= 0) {
+			file_kobj_validate_dentry_dir(&parent_dir, ndparent.dentry) <= 0) {
 			path_put(&ndupper);
 			return 0;
 		}
@@ -348,7 +348,7 @@ int file_kobj_validate_dentry(struct dentry *dentry, struct vfsmount *mnt, struc
 	//	info_mnt(real_mount(ndupper.mnt));
 	//if (ndparent.mnt)
 	//	info_mnt(real_mount(ndparent.mnt));
-	parent_dir = check(dentry, dir, &ndcurrent, &ndupper, &ndparent);
+	//parent_dir = check(dentry, dir, &ndcurrent, &ndupper, &ndparent);
 
 	if (ndparent.dentry->d_inode == NULL) {
 		medusa_put_upper_and_parent(&ndupper, &ndparent);
@@ -397,6 +397,8 @@ static enum medusa_answer_t do_file_kobj_validate_dentry(struct path *ndcurrent,
 	struct file_kobject directory;
 	enum medusa_answer_t retval;
 
+	med_pr_info("nducurrent: %pd4", ndcurrent->dentry);
+	med_pr_info("ndparent: %pd4", ndparent->dentry);
 	file_kern2kobj(&file, ndcurrent->dentry->d_inode);
 	file_kobj_dentry2string_dir(ndparent, ndupper->dentry, event.filename);
 	file_kern2kobj(&directory, ndparent->dentry->d_inode);

--- a/security/medusa/l2/kobject_file.c
+++ b/security/medusa/l2/kobject_file.c
@@ -164,7 +164,7 @@ void file_kobj_dentry2string_dir(struct path *dir, struct dentry *dentry, char *
 }
 
 /* Uses mnt from dir and then gets ndupper as original file_kobj_dentry2string() */
-void file_kobj_dentry2string_mnt(struct path *dir, struct dentry * dentry, char * buf)
+void file_kobj_dentry2string_mnt(const struct path *dir, struct dentry *dentry, char *buf)
 {
 	int len;
 


### PR DESCRIPTION
This is a dangerous work in progress. Tread carefully. Four hooks have been implemented (`mkdir`, `rmdir`, `mknod`, `unlink`). Feel free to remove unnecessary `med_pr_info` output.